### PR TITLE
feat: scaffold localized Next.js portal and jobs apps with i18n, Tailwind, Supabase and tests

### DIFF
--- a/apps/jobs/next-env.d.ts
+++ b/apps/jobs/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/apps/jobs/next.config.mjs
+++ b/apps/jobs/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/apps/jobs/package.json
+++ b/apps/jobs/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@hero/jobs",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@supabase/supabase-js": "^2.45.4",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.5.4",
+    "next": "latest",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5",
+    "@vitest/coverage-v8": "^2.0.5"
+  }
+}

--- a/apps/jobs/postcss.config.js
+++ b/apps/jobs/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/jobs/src/app/[lang]/dashboard/page.tsx
+++ b/apps/jobs/src/app/[lang]/dashboard/page.tsx
@@ -1,0 +1,46 @@
+import { FadeIn } from "@/components/motion/fade-in";
+import { SectionHeading } from "@/components/section-heading";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the dashboard page.
+ */
+export type DashboardPageProps = {
+  params: { lang: string };
+};
+
+/**
+ * Hiring dashboard page.
+ */
+export default function DashboardPage({ params }: DashboardPageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeading title={messages.dashboard.title} subtitle={messages.dashboard.subtitle} />
+      <div className="glass-panel rounded-3xl p-8 text-white">
+        <SectionHeading
+          title={messages.dashboard.pipelineTitle}
+          subtitle={messages.dashboard.pipelineSubtitle}
+        />
+        <div className="mt-6 grid gap-4 md:grid-cols-3">
+          {messages.dashboard.pipeline.map((item, index) => (
+            <FadeIn key={item.stage} delay={0.05 + index * 0.05}>
+              <div className="rounded-2xl border border-white/20 p-4">
+                <div className="text-xs uppercase tracking-[0.3em] text-white/60">{item.stage}</div>
+                <div className="mt-2 text-2xl font-semibold">{item.value}</div>
+              </div>
+            </FadeIn>
+          ))}
+        </div>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Button>{messages.dashboard.actions.primary}</Button>
+          <Button variant="ghost">{messages.dashboard.actions.secondary}</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/jobs/src/app/[lang]/error.tsx
+++ b/apps/jobs/src/app/[lang]/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Props for the locale error state.
+ */
+export type ErrorStateProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+/**
+ * Shared error state for locale routes.
+ */
+export default function ErrorState({ reset }: ErrorStateProps) {
+  const params = useParams<{ lang?: string }>();
+  const locale = getSafeLocale(params?.lang as Locale | undefined);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="glass-panel flex flex-col gap-4 rounded-3xl p-8 text-white">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">{messages.error.title}</h1>
+        <p className="text-sm text-white/70">{messages.error.subtitle}</p>
+      </div>
+      <Button onClick={reset}>{messages.error.action}</Button>
+    </div>
+  );
+}

--- a/apps/jobs/src/app/[lang]/layout.tsx
+++ b/apps/jobs/src/app/[lang]/layout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { SiteHeader } from "@/components/site-header";
+import { SiteFooter } from "@/components/site-footer";
+import { getSafeLocale, locales } from "@/lib/i18n";
+
+/**
+ * Props for the locale layout.
+ */
+export type LocaleLayoutProps = {
+  children: ReactNode;
+  params: { lang: string };
+};
+
+/**
+ * Generate static locale paths.
+ */
+export function generateStaticParams() {
+  return locales.map((lang) => ({ lang }));
+}
+
+/**
+ * Locale-aware layout with shared navigation.
+ */
+export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
+  const locale = getSafeLocale(params.lang);
+
+  return (
+    <div className="min-h-screen px-6 pb-16 pt-10">
+      <SiteHeader locale={locale} />
+      <main className="mx-auto mt-12 w-full max-w-6xl">{children}</main>
+      <SiteFooter locale={locale} />
+    </div>
+  );
+}

--- a/apps/jobs/src/app/[lang]/loading.tsx
+++ b/apps/jobs/src/app/[lang]/loading.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Shared loading state for locale routes.
+ */
+export default function LoadingState() {
+  const params = useParams<{ lang?: string }>();
+  const locale = getSafeLocale(params?.lang as Locale | undefined);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="glass-panel flex animate-pulse flex-col gap-3 rounded-3xl p-8 text-white">
+      <span className="text-lg font-semibold">{messages.loading.title}</span>
+      <span className="text-sm text-white/70">{messages.loading.subtitle}</span>
+    </div>
+  );
+}

--- a/apps/jobs/src/app/[lang]/not-found.tsx
+++ b/apps/jobs/src/app/[lang]/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the locale not-found view.
+ */
+export type NotFoundProps = {
+  params?: { lang?: string };
+};
+
+/**
+ * Locale-aware not-found view.
+ */
+export default function NotFound({ params }: NotFoundProps) {
+  const locale = getSafeLocale(params?.lang as Locale | undefined);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="glass-panel flex flex-col gap-4 rounded-3xl p-8 text-white">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">{messages.notFound.title}</h1>
+        <p className="text-sm text-white/70">{messages.notFound.subtitle}</p>
+      </div>
+      <Button asChild>
+        <Link href={`/${locale}`}>{messages.notFound.action}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/jobs/src/app/[lang]/page.tsx
+++ b/apps/jobs/src/app/[lang]/page.tsx
@@ -1,0 +1,80 @@
+import { FadeIn } from "@/components/motion/fade-in";
+import { HighlightCard } from "@/components/highlight-card";
+import { MetricCard } from "@/components/metric-card";
+import { SectionHeading } from "@/components/section-heading";
+import { Button } from "@/components/ui/button";
+import { fetchRoleListings } from "@/lib/supabase/queries";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+import { RoleCard } from "@/components/role-card";
+
+/**
+ * Props for the home page.
+ */
+export type HomePageProps = {
+  params: { lang: string };
+};
+
+/**
+ * Employer overview page.
+ */
+export default async function HomePage({ params }: HomePageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+  const listings = await fetchRoleListings(locale);
+
+  return (
+    <div className="space-y-16">
+      <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="space-y-6">
+          <FadeIn>
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70">
+              <span className="h-2 w-2 rounded-full bg-sky-300" />
+              {messages.home.heroTag}
+            </div>
+          </FadeIn>
+          <FadeIn delay={0.05}>
+            <h1 className="text-4xl font-semibold text-white md:text-5xl">
+              {messages.home.heroTitle}
+            </h1>
+          </FadeIn>
+          <FadeIn delay={0.1}>
+            <p className="text-base text-white/70 md:text-lg">{messages.home.heroSubtitle}</p>
+          </FadeIn>
+          <FadeIn delay={0.15}>
+            <Button>{messages.home.heroCta}</Button>
+          </FadeIn>
+        </div>
+        <div className="grid gap-4">
+          {messages.home.metrics.map((stat, index) => (
+            <FadeIn key={stat.label} delay={0.1 + index * 0.05}>
+              <MetricCard label={stat.label} value={stat.value} />
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <SectionHeading title={messages.roles.title} subtitle={messages.roles.subtitle} />
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {listings.map((listing, index) => (
+            <FadeIn key={listing.id} delay={0.05 + index * 0.05}>
+              <RoleCard locale={locale} listing={listing} />
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <SectionHeading title={messages.home.highlightTitle} subtitle={messages.home.highlightSubtitle} />
+        <div className="grid gap-6 md:grid-cols-3">
+          {messages.home.highlights.map((highlight, index) => (
+            <FadeIn key={highlight.title} delay={0.05 + index * 0.05}>
+              <HighlightCard title={highlight.title} description={highlight.description} />
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/jobs/src/app/[lang]/roles/[id]/page.tsx
+++ b/apps/jobs/src/app/[lang]/roles/[id]/page.tsx
@@ -1,0 +1,75 @@
+import { notFound } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { fetchRoleListings } from "@/lib/supabase/queries";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the role detail page.
+ */
+export type RoleDetailPageProps = {
+  params: { lang: string; id: string };
+};
+
+/**
+ * Detailed role command view.
+ */
+export default async function RoleDetailPage({ params }: RoleDetailPageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+  const listings = await fetchRoleListings(locale);
+  const listing = listings.find((item) => item.id === params.id);
+
+  if (!listing) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-10">
+      <section className="glass-panel rounded-3xl p-8 text-white">
+        <div className="space-y-3">
+          <div className="text-xs uppercase tracking-[0.3em] text-white/60">{listing.team}</div>
+          <h1 className="text-3xl font-semibold">{listing.title}</h1>
+          <p className="text-sm text-white/70">{listing.summary}</p>
+          <div className="flex flex-wrap gap-3 text-xs text-white/70">
+            <span className="rounded-full border border-white/20 px-3 py-1">{listing.location}</span>
+            <span className="rounded-full border border-white/20 px-3 py-1">{listing.type}</span>
+          </div>
+        </div>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Button>{messages.roleDetail.actions.primary}</Button>
+          <Button variant="ghost">{messages.roleDetail.actions.secondary}</Button>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <div className="glass-panel rounded-3xl p-6 text-white">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+            {messages.roleDetail.sections.mission}
+          </h2>
+          <p className="mt-4 text-sm text-white/70">{listing.summary}</p>
+        </div>
+        <div className="glass-panel rounded-3xl p-6 text-white">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+            {messages.roleDetail.sections.outcomes}
+          </h2>
+          <ul className="mt-4 list-disc space-y-2 pl-4 text-sm text-white/70">
+            {messages.roleDetail.outcomes.map((outcome) => (
+              <li key={outcome}>{outcome}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="glass-panel rounded-3xl p-6 text-white">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+            {messages.roleDetail.sections.traits}
+          </h2>
+          <ul className="mt-4 list-disc space-y-2 pl-4 text-sm text-white/70">
+            {messages.roleDetail.traits.map((trait) => (
+              <li key={trait}>{trait}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/jobs/src/app/[lang]/roles/page.tsx
+++ b/apps/jobs/src/app/[lang]/roles/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { FadeIn } from "@/components/motion/fade-in";
+import { SectionHeading } from "@/components/section-heading";
+import { Button } from "@/components/ui/button";
+import { fetchRoleListings } from "@/lib/supabase/queries";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the roles page.
+ */
+export type RolesPageProps = {
+  params: { lang: string };
+};
+
+/**
+ * Roles listing page.
+ */
+export default async function RolesPage({ params }: RolesPageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+  const listings = await fetchRoleListings(locale);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeading title={messages.roles.title} subtitle={messages.roles.subtitle} />
+      <div className="flex flex-wrap gap-3">
+        <span className="text-xs uppercase tracking-[0.3em] text-white/60">
+          {messages.roles.filtersLabel}
+        </span>
+        {messages.roles.filters.map((filter) => (
+          <span key={filter} className="rounded-full border border-white/20 px-3 py-1 text-xs text-white/80">
+            {filter}
+          </span>
+        ))}
+      </div>
+      <div className="grid gap-4">
+        {listings.map((listing, index) => (
+          <FadeIn key={listing.id} delay={0.05 + index * 0.05}>
+            <div className="glass-panel flex flex-col gap-4 rounded-3xl p-6 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-2">
+                <div className="text-xs uppercase tracking-[0.3em] text-white/60">{listing.team}</div>
+                <div>
+                  <h3 className="text-lg font-semibold text-white">{listing.title}</h3>
+                  <p className="text-sm text-white/70">{listing.summary}</p>
+                </div>
+                <div className="flex flex-wrap gap-3 text-xs text-white/70">
+                  <span className="rounded-full border border-white/20 px-3 py-1">{listing.location}</span>
+                  <span className="rounded-full border border-white/20 px-3 py-1">{listing.type}</span>
+                </div>
+              </div>
+              <Button asChild>
+                <Link href={`/${locale}/roles/${listing.id}`}>{messages.home.heroCta}</Link>
+              </Button>
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/jobs/src/app/layout.tsx
+++ b/apps/jobs/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import "@/styles/globals.css";
+
+/**
+ * Props for the root layout.
+ */
+export type RootLayoutProps = {
+  children: ReactNode;
+};
+
+/**
+ * Root layout shared across the application.
+ */
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en" className="scroll-smooth">
+      <body className="min-h-screen">{children}</body>
+    </html>
+  );
+}

--- a/apps/jobs/src/app/page.tsx
+++ b/apps/jobs/src/app/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+/**
+ * Redirect to the default locale.
+ */
+export default function IndexPage() {
+  redirect("/en");
+}

--- a/apps/jobs/src/components/highlight-card.tsx
+++ b/apps/jobs/src/components/highlight-card.tsx
@@ -1,0 +1,19 @@
+/**
+ * Props for the HighlightCard component.
+ */
+export type HighlightCardProps = {
+  title: string;
+  description: string;
+};
+
+/**
+ * Highlight card used on the home page.
+ */
+export function HighlightCard({ title, description }: HighlightCardProps) {
+  return (
+    <div className="glass-panel flex h-full flex-col gap-3 rounded-3xl p-6">
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+      <p className="text-sm text-white/70">{description}</p>
+    </div>
+  );
+}

--- a/apps/jobs/src/components/metric-card.tsx
+++ b/apps/jobs/src/components/metric-card.tsx
@@ -1,0 +1,19 @@
+/**
+ * Props for the MetricCard component.
+ */
+export type MetricCardProps = {
+  label: string;
+  value: string;
+};
+
+/**
+ * Statistic card for quick metrics.
+ */
+export function MetricCard({ label, value }: MetricCardProps) {
+  return (
+    <div className="glass-panel flex flex-col gap-2 rounded-2xl px-4 py-3">
+      <span className="text-xs uppercase tracking-[0.3em] text-white/60">{label}</span>
+      <span className="text-2xl font-semibold text-white">{value}</span>
+    </div>
+  );
+}

--- a/apps/jobs/src/components/motion/fade-in.tsx
+++ b/apps/jobs/src/components/motion/fade-in.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+/**
+ * Props for the FadeIn motion wrapper.
+ */
+export type FadeInProps = {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+};
+
+/**
+ * Subtle fade-in motion wrapper.
+ */
+export function FadeIn({ children, delay = 0, className }: FadeInProps) {
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/jobs/src/components/role-card.tsx
+++ b/apps/jobs/src/components/role-card.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import type { RoleListing } from "@/data/roles";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Props for the RoleCard component.
+ */
+export type RoleCardProps = {
+  locale: Locale;
+  listing: RoleListing;
+};
+
+/**
+ * Card for role listing previews.
+ */
+export function RoleCard({ locale, listing }: RoleCardProps) {
+  const messages = getMessages(locale);
+
+  return (
+    <article className="glass-panel flex h-full flex-col justify-between rounded-3xl p-6 text-white">
+      <div className="space-y-3">
+        <div className="text-xs uppercase tracking-[0.3em] text-white/60">{listing.team}</div>
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold">{listing.title}</h3>
+          <p className="text-sm text-white/70">{listing.summary}</p>
+        </div>
+        <div className="flex flex-wrap gap-3 text-xs text-white/70">
+          <span className="rounded-full border border-white/20 px-3 py-1">{listing.location}</span>
+          <span className="rounded-full border border-white/20 px-3 py-1">{listing.type}</span>
+        </div>
+      </div>
+      <div className="mt-6 flex items-center justify-between">
+        <span className="text-xs text-white/60">{messages.home.heroTag}</span>
+        <Button asChild>
+          <Link href={`/${locale}/roles/${listing.id}`}>{messages.home.heroCta}</Link>
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/apps/jobs/src/components/section-heading.tsx
+++ b/apps/jobs/src/components/section-heading.tsx
@@ -1,0 +1,19 @@
+/**
+ * Props for the SectionHeading component.
+ */
+export type SectionHeadingProps = {
+  title: string;
+  subtitle: string;
+};
+
+/**
+ * Section heading with title and subtitle.
+ */
+export function SectionHeading({ title, subtitle }: SectionHeadingProps) {
+  return (
+    <div className="space-y-2">
+      <h2 className="text-2xl font-semibold text-white">{title}</h2>
+      <p className="text-sm text-white/70">{subtitle}</p>
+    </div>
+  );
+}

--- a/apps/jobs/src/components/site-footer.tsx
+++ b/apps/jobs/src/components/site-footer.tsx
@@ -1,0 +1,26 @@
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Props for the SiteFooter component.
+ */
+export type SiteFooterProps = {
+  locale: Locale;
+};
+
+/**
+ * Shared site footer.
+ */
+export function SiteFooter({ locale }: SiteFooterProps) {
+  const messages = getMessages(locale);
+
+  return (
+    <footer className="glass-panel mx-auto mt-16 w-full max-w-6xl rounded-3xl px-8 py-6 text-sm text-white/70">
+      <div className="flex flex-col gap-2">
+        <span className="text-white">{messages.footer.title}</span>
+        <span>{messages.footer.description}</span>
+        <span className="text-white/60">{messages.footer.secondary}</span>
+      </div>
+    </footer>
+  );
+}

--- a/apps/jobs/src/components/site-header.tsx
+++ b/apps/jobs/src/components/site-header.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Props for the SiteHeader component.
+ */
+export type SiteHeaderProps = {
+  locale: Locale;
+};
+
+/**
+ * Shared site header with navigation.
+ */
+export function SiteHeader({ locale }: SiteHeaderProps) {
+  const messages = getMessages(locale);
+
+  return (
+    <header className="glass-panel sticky top-6 z-20 mx-auto flex w-full max-w-6xl items-center justify-between gap-6 rounded-full px-6 py-3">
+      <div className="flex items-center gap-3 text-sm font-semibold text-white">
+        <span className="h-2 w-2 rounded-full bg-sky-300 shadow-[0_0_12px_rgba(56,189,248,0.8)]" />
+        {messages.nav.brand}
+      </div>
+      <nav className="hidden items-center gap-5 text-sm text-white/80 md:flex">
+        {messages.nav.primaryLinks.map((link) => (
+          <Link key={link.href} href={link.href} className="hover:text-white">
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+      <Button>{messages.nav.cta}</Button>
+    </header>
+  );
+}

--- a/apps/jobs/src/components/ui/button.tsx
+++ b/apps/jobs/src/components/ui/button.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cn } from "@/lib/utils";
+
+/**
+ * Props for the Button component.
+ */
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+  variant?: "default" | "ghost";
+};
+
+/**
+ * ShadCN-inspired button component.
+ */
+export function Button({
+  asChild = false,
+  className,
+  variant = "default",
+  ...props
+}: ButtonProps) {
+  const Component = asChild ? Slot : "button";
+
+  return (
+    <Component
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition",
+        variant === "default" &&
+          "bg-white text-ink shadow-glow hover:-translate-y-0.5 hover:shadow-glow/80",
+        variant === "ghost" &&
+          "border border-white/30 text-white/90 hover:border-white/60 hover:text-white",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/jobs/src/data/roles.test.ts
+++ b/apps/jobs/src/data/roles.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getRoleListings } from "@/data/roles";
+
+describe("role listings", () => {
+  it("returns localized listings", () => {
+    const listings = getRoleListings("en");
+
+    expect(listings.length).toBeGreaterThan(0);
+    expect(listings[0]).toHaveProperty("id");
+    expect(listings[0]).toHaveProperty("title");
+  });
+});

--- a/apps/jobs/src/data/roles.ts
+++ b/apps/jobs/src/data/roles.ts
@@ -1,0 +1,21 @@
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Shape of a role listing card.
+ */
+export type RoleListing = {
+  id: string;
+  title: string;
+  team: string;
+  location: string;
+  type: string;
+  summary: string;
+};
+
+/**
+ * Return role listings for the selected locale.
+ */
+export function getRoleListings(locale: Locale): RoleListing[] {
+  return getMessages(locale).roles.listings;
+}

--- a/apps/jobs/src/lib/i18n.test.ts
+++ b/apps/jobs/src/lib/i18n.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getMessages, getSafeLocale, isLocale, locales } from "@/lib/i18n";
+
+describe("i18n", () => {
+  it("exposes supported locales", () => {
+    expect(locales).toContain("en");
+    expect(locales).toContain("nl");
+  });
+
+  it("validates locales", () => {
+    expect(isLocale("en")).toBe(true);
+    expect(isLocale("nl")).toBe(true);
+    expect(isLocale("fr")).toBe(false);
+  });
+
+  it("returns messages for a locale", () => {
+    const messages = getMessages("en");
+
+    expect(messages.nav.brand).toBeTypeOf("string");
+    expect(messages.home.metrics.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a safe locale", () => {
+    expect(getSafeLocale("nl")).toBe("nl");
+    expect(getSafeLocale("fr")).toBe("en");
+    expect(getSafeLocale()).toBe("en");
+  });
+});

--- a/apps/jobs/src/lib/i18n.ts
+++ b/apps/jobs/src/lib/i18n.ts
@@ -1,0 +1,41 @@
+import { en } from "@/locales/en";
+import { nl } from "@/locales/nl";
+
+/**
+ * Supported locale codes.
+ */
+export const locales = ["en", "nl"] as const;
+
+/**
+ * Union type of supported locales.
+ */
+export type Locale = (typeof locales)[number];
+
+const messages = {
+  en,
+  nl
+} satisfies Record<Locale, typeof en>;
+
+/**
+ * Determine whether a locale is supported.
+ */
+export function isLocale(value: string): value is Locale {
+  return locales.includes(value as Locale);
+}
+
+/**
+ * Get localized copy for the provided locale.
+ */
+export function getMessages(locale: Locale) {
+  return messages[locale];
+}
+
+/**
+ * Select a safe locale fallback.
+ */
+export function getSafeLocale(value?: string): Locale {
+  if (value && isLocale(value)) {
+    return value;
+  }
+  return "en";
+}

--- a/apps/jobs/src/lib/supabase/queries.ts
+++ b/apps/jobs/src/lib/supabase/queries.ts
@@ -1,0 +1,27 @@
+import type { RoleListing } from "@/data/roles";
+import type { Locale } from "@/lib/i18n";
+import { getRoleListings } from "@/data/roles";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+/**
+ * Fetch role listings from a public view, falling back to locale content.
+ */
+export async function fetchRoleListings(locale: Locale): Promise<RoleListing[]> {
+  const supabase = createSupabaseServerClient();
+
+  if (!supabase) {
+    return getRoleListings(locale);
+  }
+
+  const { data, error } = await supabase
+    .schema("public")
+    .from("role_listings_view")
+    .select("id,title,team,location,type,summary")
+    .order("id");
+
+  if (error || !data) {
+    return getRoleListings(locale);
+  }
+
+  return data;
+}

--- a/apps/jobs/src/lib/supabase/server.ts
+++ b/apps/jobs/src/lib/supabase/server.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Build a Supabase server client using environment configuration.
+ */
+export function createSupabaseServerClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    return null;
+  }
+
+  return createClient(url, key, {
+    auth: {
+      persistSession: false
+    }
+  });
+}

--- a/apps/jobs/src/lib/utils.ts
+++ b/apps/jobs/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merge Tailwind class names with conditional support.
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/jobs/src/locales/en.ts
+++ b/apps/jobs/src/locales/en.ts
@@ -1,0 +1,130 @@
+/**
+ * English copy for the jobs app.
+ */
+export const en = {
+  languageLabel: "English",
+  nav: {
+    brand: "Hero Jobs",
+    primaryLinks: [
+      { href: "/en", label: "Employer overview" },
+      { href: "/en/roles", label: "Role roster" },
+      { href: "/en/dashboard", label: "Hiring dashboard" }
+    ],
+    cta: "Launch a role"
+  },
+  footer: {
+    title: "Recruitment control",
+    description: "Real-time hiring intelligence for mission operators.",
+    secondary: "Built on secure, compliant talent workflows."
+  },
+  home: {
+    heroTitle: "Design the next hero mission",
+    heroSubtitle: "Centralize roles, candidates, and progress with high-trust workflows.",
+    heroCta: "Review hiring status",
+    heroTag: "Employer-ready command",
+    highlightTitle: "Why teams choose Hero Jobs",
+    highlightSubtitle: "Operations-first hiring with transparent visibility.",
+    metrics: [
+      { label: "Open roles", value: "18" },
+      { label: "Heroes in review", value: "57" },
+      { label: "Avg. fill time", value: "16 days" }
+    ],
+    highlights: [
+      {
+        title: "Mission-ready pipelines",
+        description: "Track candidates across stages with real-time alerts."
+      },
+      {
+        title: "Secure approvals",
+        description: "Every write flows through public functions with RLS."
+      },
+      {
+        title: "Partnered recruiters",
+        description: "Dedicated partners keep every hire on track."
+      }
+    ]
+  },
+  roles: {
+    title: "Active role roster",
+    subtitle: "Open missions ready for hero candidates.",
+    filtersLabel: "Role type",
+    filters: ["Leadership", "Operations", "Engineering", "Design"],
+    listings: [
+      {
+        id: "solar-core",
+        title: "Director of Hero Operations",
+        team: "Solar Core",
+        location: "Rotterdam, NL",
+        type: "Hybrid",
+        summary: "Lead hero operational readiness and escalation reviews."
+      },
+      {
+        id: "lumen-signal",
+        title: "Talent Signal Analyst",
+        team: "Lumen Signal",
+        location: "Remote",
+        type: "Remote",
+        summary: "Analyze hiring funnel quality with mission metrics."
+      },
+      {
+        id: "orbit-design",
+        title: "Experience Design Lead",
+        team: "Orbit Labs",
+        location: "Amsterdam, NL",
+        type: "On-site",
+        summary: "Craft tactile hero onboarding experiences."
+      }
+    ]
+  },
+  roleDetail: {
+    title: "Role command brief",
+    sections: {
+      mission: "Mission scope",
+      outcomes: "Hiring outcomes",
+      traits: "Ideal traits"
+    },
+    actions: {
+      primary: "Open shortlist",
+      secondary: "Share brief"
+    },
+    outcomes: [
+      "Secure candidate slate within 10 days",
+      "Complete mission briefing packet",
+      "Launch onboarding plan"
+    ],
+    traits: [
+      "Executive-level clarity",
+      "Operational rigor",
+      "Cross-functional leadership"
+    ]
+  },
+  dashboard: {
+    title: "Hiring dashboard",
+    subtitle: "Monitor hiring throughput and mission readiness.",
+    pipelineTitle: "Current pipeline",
+    pipelineSubtitle: "Live stages across every active role.",
+    pipeline: [
+      { stage: "New", value: "22" },
+      { stage: "Review", value: "11" },
+      { stage: "Offer", value: "4" }
+    ],
+    actions: {
+      primary: "Approve missions",
+      secondary: "Invite stakeholders"
+    }
+  },
+  loading: {
+    title: "Syncing hiring signals",
+    subtitle: "Refreshing mission intelligence."
+  },
+  error: {
+    title: "Command interruption",
+    subtitle: "Unable to load this view. Please retry.",
+    action: "Retry"
+  },
+  notFound: {
+    title: "Signal not found",
+    subtitle: "This route is outside the mission grid.",
+    action: "Return home"
+  }
+} as const;

--- a/apps/jobs/src/locales/nl.ts
+++ b/apps/jobs/src/locales/nl.ts
@@ -1,0 +1,130 @@
+/**
+ * Dutch copy for the jobs app.
+ */
+export const nl = {
+  languageLabel: "Nederlands",
+  nav: {
+    brand: "Hero Jobs",
+    primaryLinks: [
+      { href: "/nl", label: "Werkgever overzicht" },
+      { href: "/nl/roles", label: "Roloverzicht" },
+      { href: "/nl/dashboard", label: "Hiring dashboard" }
+    ],
+    cta: "Start een rol"
+  },
+  footer: {
+    title: "Recruitment control",
+    description: "Realtime hiring intelligence voor mission operators.",
+    secondary: "Gebouwd op veilige, compliant talent workflows."
+  },
+  home: {
+    heroTitle: "Ontwerp de volgende hero missie",
+    heroSubtitle: "Centraliseer rollen, kandidaten en voortgang met vertrouwen.",
+    heroCta: "Bekijk hiring status",
+    heroTag: "Employer-ready command",
+    highlightTitle: "Waarom teams Hero Jobs kiezen",
+    highlightSubtitle: "Operations-first hiring met transparante zichtbaarheid.",
+    metrics: [
+      { label: "Open rollen", value: "18" },
+      { label: "Heroes in review", value: "57" },
+      { label: "Gem. vultijd", value: "16 dagen" }
+    ],
+    highlights: [
+      {
+        title: "Missieklare pipelines",
+        description: "Volg kandidaten met realtime alerts."
+      },
+      {
+        title: "Veilige approvals",
+        description: "Elke write gaat via public functions met RLS."
+      },
+      {
+        title: "Recruitment partners",
+        description: "Dedicated partners houden elke hire on track."
+      }
+    ]
+  },
+  roles: {
+    title: "Actieve rol roster",
+    subtitle: "Open missies klaar voor hero kandidaten.",
+    filtersLabel: "Roltype",
+    filters: ["Leiderschap", "Operations", "Engineering", "Design"],
+    listings: [
+      {
+        id: "solar-core",
+        title: "Director Hero Operations",
+        team: "Solar Core",
+        location: "Rotterdam, NL",
+        type: "Hybride",
+        summary: "Leid hero operationele readiness en escalatie reviews."
+      },
+      {
+        id: "lumen-signal",
+        title: "Talent Signal Analyst",
+        team: "Lumen Signal",
+        location: "Remote",
+        type: "Remote",
+        summary: "Analyseer hiring funnel kwaliteit met mission metrics."
+      },
+      {
+        id: "orbit-design",
+        title: "Experience Design Lead",
+        team: "Orbit Labs",
+        location: "Amsterdam, NL",
+        type: "On-site",
+        summary: "Ontwerp tactiele hero onboarding ervaringen."
+      }
+    ]
+  },
+  roleDetail: {
+    title: "Rol command brief",
+    sections: {
+      mission: "Missiescope",
+      outcomes: "Hiring outcomes",
+      traits: "Ideale traits"
+    },
+    actions: {
+      primary: "Open shortlist",
+      secondary: "Deel brief"
+    },
+    outcomes: [
+      "Lever candidate slate binnen 10 dagen",
+      "Voltooi mission briefing packet",
+      "Start onboarding plan"
+    ],
+    traits: [
+      "Executive-level helderheid",
+      "Operationele nauwkeurigheid",
+      "Cross-functioneel leiderschap"
+    ]
+  },
+  dashboard: {
+    title: "Hiring dashboard",
+    subtitle: "Monitor throughput en mission readiness.",
+    pipelineTitle: "Huidige pipeline",
+    pipelineSubtitle: "Live stages voor elke actieve rol.",
+    pipeline: [
+      { stage: "Nieuw", value: "22" },
+      { stage: "Review", value: "11" },
+      { stage: "Offer", value: "4" }
+    ],
+    actions: {
+      primary: "Keuring missies",
+      secondary: "Nodig stakeholders uit"
+    }
+  },
+  loading: {
+    title: "Hiring signals synchroniseren",
+    subtitle: "Mission intelligence wordt geladen."
+  },
+  error: {
+    title: "Command onderbroken",
+    subtitle: "We kunnen dit scherm niet laden. Probeer opnieuw.",
+    action: "Probeer opnieuw"
+  },
+  notFound: {
+    title: "Signaal niet gevonden",
+    subtitle: "Deze route valt buiten de missiegrid.",
+    action: "Terug naar start"
+  }
+} as const;

--- a/apps/jobs/src/styles/globals.css
+++ b/apps/jobs/src/styles/globals.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-950 text-white min-h-screen antialiased;
+  background-image: radial-gradient(circle at top, rgba(14, 165, 233, 0.35), transparent 45%),
+    radial-gradient(circle at 20% 20%, rgba(45, 212, 191, 0.25), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.2), transparent 35%);
+}
+
+main {
+  @apply relative z-10;
+}
+
+.glass-panel {
+  @apply bg-glass/30 border border-glass-border shadow-glass backdrop-blur-glass;
+}

--- a/apps/jobs/tailwind.config.ts
+++ b/apps/jobs/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        glass: "rgba(255, 255, 255, 0.7)",
+        "glass-border": "rgba(148, 163, 184, 0.2)",
+        ink: "#0f172a",
+        accent: "#0ea5e9"
+      },
+      boxShadow: {
+        glass: "0 20px 60px -40px rgba(15, 23, 42, 0.6)",
+        glow: "0 0 50px rgba(14, 165, 233, 0.25)"
+      },
+      backdropBlur: {
+        glass: "18px"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/jobs/tsconfig.json
+++ b/apps/jobs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../packages/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "src", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/jobs/vitest.config.ts
+++ b/apps/jobs/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/lib/**/*.ts", "src/data/**/*.ts"],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80
+      }
+    }
+  }
+});

--- a/apps/portal/next-env.d.ts
+++ b/apps/portal/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/apps/portal/next.config.mjs
+++ b/apps/portal/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@hero/portal",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "@supabase/supabase-js": "^2.45.4",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.5.4",
+    "next": "latest",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5",
+    "@vitest/coverage-v8": "^2.0.5"
+  }
+}

--- a/apps/portal/postcss.config.js
+++ b/apps/portal/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/portal/src/app/[lang]/employer/page.tsx
+++ b/apps/portal/src/app/[lang]/employer/page.tsx
@@ -1,0 +1,46 @@
+import { FadeIn } from "@/components/motion/fade-in";
+import { SectionHeading } from "@/components/section-heading";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the employer dashboard page.
+ */
+export type EmployerPageProps = {
+  params: { lang: string };
+};
+
+/**
+ * Employer dashboard page.
+ */
+export default function EmployerPage({ params }: EmployerPageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeading title={messages.employer.title} subtitle={messages.employer.subtitle} />
+      <div className="glass-panel rounded-3xl p-8 text-white">
+        <SectionHeading
+          title={messages.employer.pipelineTitle}
+          subtitle={messages.employer.pipelineSubtitle}
+        />
+        <div className="mt-6 grid gap-4 md:grid-cols-3">
+          {messages.employer.pipeline.map((item, index) => (
+            <FadeIn key={item.stage} delay={0.05 + index * 0.05}>
+              <div className="rounded-2xl border border-white/20 p-4">
+                <div className="text-xs uppercase tracking-[0.3em] text-white/60">{item.stage}</div>
+                <div className="mt-2 text-2xl font-semibold">{item.value}</div>
+              </div>
+            </FadeIn>
+          ))}
+        </div>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Button>{messages.employer.actions.primary}</Button>
+          <Button variant="ghost">{messages.employer.actions.secondary}</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/src/app/[lang]/error.tsx
+++ b/apps/portal/src/app/[lang]/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Props for the locale error state.
+ */
+export type ErrorStateProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+/**
+ * Shared error state for locale routes.
+ */
+export default function ErrorState({ reset }: ErrorStateProps) {
+  const params = useParams<{ lang?: string }>();
+  const locale = getSafeLocale(params?.lang as Locale | undefined);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="glass-panel flex flex-col gap-4 rounded-3xl p-8 text-white">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">{messages.error.title}</h1>
+        <p className="text-sm text-white/70">{messages.error.subtitle}</p>
+      </div>
+      <Button onClick={reset}>{messages.error.action}</Button>
+    </div>
+  );
+}

--- a/apps/portal/src/app/[lang]/jobs/[id]/page.tsx
+++ b/apps/portal/src/app/[lang]/jobs/[id]/page.tsx
@@ -1,0 +1,75 @@
+import { notFound } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { fetchHeroListings } from "@/lib/supabase/queries";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the job detail page.
+ */
+export type JobDetailPageProps = {
+  params: { lang: string; id: string };
+};
+
+/**
+ * Detailed hero role view.
+ */
+export default async function JobDetailPage({ params }: JobDetailPageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+  const listings = await fetchHeroListings(locale);
+  const listing = listings.find((item) => item.id === params.id);
+
+  if (!listing) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-10">
+      <section className="glass-panel rounded-3xl p-8 text-white">
+        <div className="space-y-3">
+          <div className="text-xs uppercase tracking-[0.3em] text-white/60">{listing.team}</div>
+          <h1 className="text-3xl font-semibold">{listing.title}</h1>
+          <p className="text-sm text-white/70">{listing.summary}</p>
+          <div className="flex flex-wrap gap-3 text-xs text-white/70">
+            <span className="rounded-full border border-white/20 px-3 py-1">{listing.location}</span>
+            <span className="rounded-full border border-white/20 px-3 py-1">{listing.type}</span>
+          </div>
+        </div>
+        <div className="mt-8 flex flex-wrap gap-3">
+          <Button>{messages.jobDetail.actions.primary}</Button>
+          <Button variant="ghost">{messages.jobDetail.actions.secondary}</Button>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-3">
+        <div className="glass-panel rounded-3xl p-6 text-white">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+            {messages.jobDetail.sections.mission}
+          </h2>
+          <p className="mt-4 text-sm text-white/70">{listing.summary}</p>
+        </div>
+        <div className="glass-panel rounded-3xl p-6 text-white">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+            {messages.jobDetail.sections.outcomes}
+          </h2>
+          <ul className="mt-4 list-disc space-y-2 pl-4 text-sm text-white/70">
+            {messages.jobDetail.outcomes.map((outcome) => (
+              <li key={outcome}>{outcome}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="glass-panel rounded-3xl p-6 text-white">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.3em] text-white/60">
+            {messages.jobDetail.sections.traits}
+          </h2>
+          <ul className="mt-4 list-disc space-y-2 pl-4 text-sm text-white/70">
+            {messages.jobDetail.traits.map((trait) => (
+              <li key={trait}>{trait}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/portal/src/app/[lang]/jobs/page.tsx
+++ b/apps/portal/src/app/[lang]/jobs/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { FadeIn } from "@/components/motion/fade-in";
+import { SectionHeading } from "@/components/section-heading";
+import { Button } from "@/components/ui/button";
+import { fetchHeroListings } from "@/lib/supabase/queries";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the jobs page.
+ */
+export type JobsPageProps = {
+  params: { lang: string };
+};
+
+/**
+ * Hero jobs listing page.
+ */
+export default async function JobsPage({ params }: JobsPageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+  const listings = await fetchHeroListings(locale);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeading title={messages.jobs.title} subtitle={messages.jobs.subtitle} />
+      <div className="flex flex-wrap gap-3">
+        <span className="text-xs uppercase tracking-[0.3em] text-white/60">
+          {messages.jobs.filtersLabel}
+        </span>
+        {messages.jobs.filters.map((filter) => (
+          <span key={filter} className="rounded-full border border-white/20 px-3 py-1 text-xs text-white/80">
+            {filter}
+          </span>
+        ))}
+      </div>
+      <div className="grid gap-4">
+        {listings.map((listing, index) => (
+          <FadeIn key={listing.id} delay={0.05 + index * 0.05}>
+            <div className="glass-panel flex flex-col gap-4 rounded-3xl p-6 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-2">
+                <div className="text-xs uppercase tracking-[0.3em] text-white/60">{listing.team}</div>
+                <div>
+                  <h3 className="text-lg font-semibold text-white">{listing.title}</h3>
+                  <p className="text-sm text-white/70">{listing.summary}</p>
+                </div>
+                <div className="flex flex-wrap gap-3 text-xs text-white/70">
+                  <span className="rounded-full border border-white/20 px-3 py-1">{listing.location}</span>
+                  <span className="rounded-full border border-white/20 px-3 py-1">{listing.type}</span>
+                </div>
+              </div>
+              <Button asChild>
+                <Link href={`/${locale}/jobs/${listing.id}`}>{messages.home.heroCta}</Link>
+              </Button>
+            </div>
+          </FadeIn>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/portal/src/app/[lang]/layout.tsx
+++ b/apps/portal/src/app/[lang]/layout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+import { SiteHeader } from "@/components/site-header";
+import { SiteFooter } from "@/components/site-footer";
+import { getSafeLocale, locales } from "@/lib/i18n";
+
+/**
+ * Props for the locale layout.
+ */
+export type LocaleLayoutProps = {
+  children: ReactNode;
+  params: { lang: string };
+};
+
+/**
+ * Generate static locale paths.
+ */
+export function generateStaticParams() {
+  return locales.map((lang) => ({ lang }));
+}
+
+/**
+ * Locale-aware layout with shared navigation.
+ */
+export default function LocaleLayout({ children, params }: LocaleLayoutProps) {
+  const locale = getSafeLocale(params.lang);
+
+  return (
+    <div className="min-h-screen px-6 pb-16 pt-10">
+      <SiteHeader locale={locale} />
+      <main className="mx-auto mt-12 w-full max-w-6xl">{children}</main>
+      <SiteFooter locale={locale} />
+    </div>
+  );
+}

--- a/apps/portal/src/app/[lang]/loading.tsx
+++ b/apps/portal/src/app/[lang]/loading.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Shared loading state for locale routes.
+ */
+export default function LoadingState() {
+  const params = useParams<{ lang?: string }>();
+  const locale = getSafeLocale(params?.lang as Locale | undefined);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="glass-panel flex animate-pulse flex-col gap-3 rounded-3xl p-8 text-white">
+      <span className="text-lg font-semibold">{messages.loading.title}</span>
+      <span className="text-sm text-white/70">{messages.loading.subtitle}</span>
+    </div>
+  );
+}

--- a/apps/portal/src/app/[lang]/not-found.tsx
+++ b/apps/portal/src/app/[lang]/not-found.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the locale not-found view.
+ */
+export type NotFoundProps = {
+  params?: { lang?: string };
+};
+
+/**
+ * Locale-aware not-found view.
+ */
+export default function NotFound({ params }: NotFoundProps) {
+  const locale = getSafeLocale(params?.lang as Locale | undefined);
+  const messages = getMessages(locale);
+
+  return (
+    <div className="glass-panel flex flex-col gap-4 rounded-3xl p-8 text-white">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">{messages.notFound.title}</h1>
+        <p className="text-sm text-white/70">{messages.notFound.subtitle}</p>
+      </div>
+      <Button asChild>
+        <Link href={`/${locale}`}>{messages.notFound.action}</Link>
+      </Button>
+    </div>
+  );
+}

--- a/apps/portal/src/app/[lang]/page.tsx
+++ b/apps/portal/src/app/[lang]/page.tsx
@@ -1,0 +1,80 @@
+import { FadeIn } from "@/components/motion/fade-in";
+import { HighlightCard } from "@/components/highlight-card";
+import { HeroCard } from "@/components/hero-card";
+import { MetricCard } from "@/components/metric-card";
+import { SectionHeading } from "@/components/section-heading";
+import { Button } from "@/components/ui/button";
+import { fetchHeroListings } from "@/lib/supabase/queries";
+import type { Locale } from "@/lib/i18n";
+import { getMessages, getSafeLocale } from "@/lib/i18n";
+
+/**
+ * Props for the home page.
+ */
+export type HomePageProps = {
+  params: { lang: string };
+};
+
+/**
+ * Portal home page.
+ */
+export default async function HomePage({ params }: HomePageProps) {
+  const locale = getSafeLocale(params.lang as Locale);
+  const messages = getMessages(locale);
+  const listings = await fetchHeroListings(locale);
+
+  return (
+    <div className="space-y-16">
+      <section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr]">
+        <div className="space-y-6">
+          <FadeIn>
+            <div className="inline-flex items-center gap-2 rounded-full border border-white/20 px-4 py-2 text-xs uppercase tracking-[0.3em] text-white/70">
+              <span className="h-2 w-2 rounded-full bg-indigo-300" />
+              {messages.home.heroTag}
+            </div>
+          </FadeIn>
+          <FadeIn delay={0.05}>
+            <h1 className="text-4xl font-semibold text-white md:text-5xl">
+              {messages.home.heroTitle}
+            </h1>
+          </FadeIn>
+          <FadeIn delay={0.1}>
+            <p className="text-base text-white/70 md:text-lg">{messages.home.heroSubtitle}</p>
+          </FadeIn>
+          <FadeIn delay={0.15}>
+            <Button>{messages.home.heroCta}</Button>
+          </FadeIn>
+        </div>
+        <div className="grid gap-4">
+          {messages.home.stats.map((stat, index) => (
+            <FadeIn key={stat.label} delay={0.1 + index * 0.05}>
+              <MetricCard label={stat.label} value={stat.value} />
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <SectionHeading title={messages.home.highlightTitle} subtitle={messages.home.highlightSubtitle} />
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {listings.map((listing, index) => (
+            <FadeIn key={listing.id} delay={0.05 + index * 0.05}>
+              <HeroCard locale={locale} listing={listing} />
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <SectionHeading title={messages.home.heroListingsTitle} subtitle={messages.home.heroListingsSubtitle} />
+        <div className="grid gap-6 md:grid-cols-3">
+          {messages.home.highlights.map((highlight, index) => (
+            <FadeIn key={highlight.title} delay={0.05 + index * 0.05}>
+              <HighlightCard title={highlight.title} description={highlight.description} />
+            </FadeIn>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/portal/src/app/layout.tsx
+++ b/apps/portal/src/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import "@/styles/globals.css";
+
+/**
+ * Props for the root layout.
+ */
+export type RootLayoutProps = {
+  children: ReactNode;
+};
+
+/**
+ * Root layout shared across the application.
+ */
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en" className="scroll-smooth">
+      <body className="min-h-screen">{children}</body>
+    </html>
+  );
+}

--- a/apps/portal/src/app/page.tsx
+++ b/apps/portal/src/app/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+/**
+ * Redirect to the default locale.
+ */
+export default function IndexPage() {
+  redirect("/en");
+}

--- a/apps/portal/src/components/hero-card.tsx
+++ b/apps/portal/src/components/hero-card.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import type { HeroListing } from "@/data/hero";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Props for the HeroCard component.
+ */
+export type HeroCardProps = {
+  locale: Locale;
+  listing: HeroListing;
+};
+
+/**
+ * Card for hero listing previews.
+ */
+export function HeroCard({ locale, listing }: HeroCardProps) {
+  const messages = getMessages(locale);
+
+  return (
+    <article className="glass-panel flex h-full flex-col justify-between rounded-3xl p-6 text-white">
+      <div className="space-y-3">
+        <div className="text-xs uppercase tracking-[0.3em] text-white/60">
+          {listing.team}
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold">{listing.title}</h3>
+          <p className="text-sm text-white/70">{listing.summary}</p>
+        </div>
+        <div className="flex flex-wrap gap-3 text-xs text-white/70">
+          <span className="rounded-full border border-white/20 px-3 py-1">{listing.location}</span>
+          <span className="rounded-full border border-white/20 px-3 py-1">{listing.type}</span>
+        </div>
+      </div>
+      <div className="mt-6 flex items-center justify-between">
+        <span className="text-xs text-white/60">{messages.home.heroTag}</span>
+        <Button asChild>
+          <Link href={`/${locale}/jobs/${listing.id}`}>
+            {messages.home.heroCta}
+          </Link>
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/apps/portal/src/components/highlight-card.tsx
+++ b/apps/portal/src/components/highlight-card.tsx
@@ -1,0 +1,19 @@
+/**
+ * Props for the HighlightCard component.
+ */
+export type HighlightCardProps = {
+  title: string;
+  description: string;
+};
+
+/**
+ * Highlight card used on the home page.
+ */
+export function HighlightCard({ title, description }: HighlightCardProps) {
+  return (
+    <div className="glass-panel flex h-full flex-col gap-3 rounded-3xl p-6">
+      <h3 className="text-lg font-semibold text-white">{title}</h3>
+      <p className="text-sm text-white/70">{description}</p>
+    </div>
+  );
+}

--- a/apps/portal/src/components/metric-card.tsx
+++ b/apps/portal/src/components/metric-card.tsx
@@ -1,0 +1,19 @@
+/**
+ * Props for the MetricCard component.
+ */
+export type MetricCardProps = {
+  label: string;
+  value: string;
+};
+
+/**
+ * Statistic card for quick metrics.
+ */
+export function MetricCard({ label, value }: MetricCardProps) {
+  return (
+    <div className="glass-panel flex flex-col gap-2 rounded-2xl px-4 py-3">
+      <span className="text-xs uppercase tracking-[0.3em] text-white/60">{label}</span>
+      <span className="text-2xl font-semibold text-white">{value}</span>
+    </div>
+  );
+}

--- a/apps/portal/src/components/motion/fade-in.tsx
+++ b/apps/portal/src/components/motion/fade-in.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+
+/**
+ * Props for the FadeIn motion wrapper.
+ */
+export type FadeInProps = {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+};
+
+/**
+ * Subtle fade-in motion wrapper.
+ */
+export function FadeIn({ children, delay = 0, className }: FadeInProps) {
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/apps/portal/src/components/section-heading.tsx
+++ b/apps/portal/src/components/section-heading.tsx
@@ -1,0 +1,19 @@
+/**
+ * Props for the SectionHeading component.
+ */
+export type SectionHeadingProps = {
+  title: string;
+  subtitle: string;
+};
+
+/**
+ * Section heading with title and subtitle.
+ */
+export function SectionHeading({ title, subtitle }: SectionHeadingProps) {
+  return (
+    <div className="space-y-2">
+      <h2 className="text-2xl font-semibold text-white">{title}</h2>
+      <p className="text-sm text-white/70">{subtitle}</p>
+    </div>
+  );
+}

--- a/apps/portal/src/components/site-footer.tsx
+++ b/apps/portal/src/components/site-footer.tsx
@@ -1,0 +1,26 @@
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Props for the SiteFooter component.
+ */
+export type SiteFooterProps = {
+  locale: Locale;
+};
+
+/**
+ * Shared site footer.
+ */
+export function SiteFooter({ locale }: SiteFooterProps) {
+  const messages = getMessages(locale);
+
+  return (
+    <footer className="glass-panel mx-auto mt-16 w-full max-w-6xl rounded-3xl px-8 py-6 text-sm text-white/70">
+      <div className="flex flex-col gap-2">
+        <span className="text-white">{messages.footer.title}</span>
+        <span>{messages.footer.description}</span>
+        <span className="text-white/60">{messages.footer.secondary}</span>
+      </div>
+    </footer>
+  );
+}

--- a/apps/portal/src/components/site-header.tsx
+++ b/apps/portal/src/components/site-header.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Props for the SiteHeader component.
+ */
+export type SiteHeaderProps = {
+  locale: Locale;
+};
+
+/**
+ * Shared site header with navigation.
+ */
+export function SiteHeader({ locale }: SiteHeaderProps) {
+  const messages = getMessages(locale);
+
+  return (
+    <header className="glass-panel sticky top-6 z-20 mx-auto flex w-full max-w-6xl items-center justify-between gap-6 rounded-full px-6 py-3">
+      <div className="flex items-center gap-3 text-sm font-semibold text-white">
+        <span className="h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_12px_rgba(52,211,153,0.8)]" />
+        {messages.nav.brand}
+      </div>
+      <nav className="hidden items-center gap-5 text-sm text-white/80 md:flex">
+        {messages.nav.primaryLinks.map((link) => (
+          <Link key={link.href} href={link.href} className="hover:text-white">
+            {link.label}
+          </Link>
+        ))}
+      </nav>
+      <Button>{messages.nav.cta}</Button>
+    </header>
+  );
+}

--- a/apps/portal/src/components/ui/button.tsx
+++ b/apps/portal/src/components/ui/button.tsx
@@ -1,0 +1,37 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cn } from "@/lib/utils";
+
+/**
+ * Props for the Button component.
+ */
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  asChild?: boolean;
+  variant?: "default" | "ghost";
+};
+
+/**
+ * ShadCN-inspired button component.
+ */
+export function Button({
+  asChild = false,
+  className,
+  variant = "default",
+  ...props
+}: ButtonProps) {
+  const Component = asChild ? Slot : "button";
+
+  return (
+    <Component
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-full px-5 py-2 text-sm font-semibold transition",
+        variant === "default" &&
+          "bg-white text-ink shadow-glow hover:-translate-y-0.5 hover:shadow-glow/80",
+        variant === "ghost" &&
+          "border border-white/30 text-white/90 hover:border-white/60 hover:text-white",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/portal/src/data/hero.test.ts
+++ b/apps/portal/src/data/hero.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getHeroListings } from "@/data/hero";
+
+
+describe("hero listings", () => {
+  it("returns localized listings", () => {
+    const listings = getHeroListings("en");
+
+    expect(listings.length).toBeGreaterThan(0);
+    expect(listings[0]).toHaveProperty("id");
+    expect(listings[0]).toHaveProperty("title");
+  });
+});

--- a/apps/portal/src/data/hero.ts
+++ b/apps/portal/src/data/hero.ts
@@ -1,0 +1,21 @@
+import type { Locale } from "@/lib/i18n";
+import { getMessages } from "@/lib/i18n";
+
+/**
+ * Shape of a hero listing card.
+ */
+export type HeroListing = {
+  id: string;
+  title: string;
+  team: string;
+  location: string;
+  type: string;
+  summary: string;
+};
+
+/**
+ * Return hero listings for the selected locale.
+ */
+export function getHeroListings(locale: Locale): HeroListing[] {
+  return getMessages(locale).jobs.listings;
+}

--- a/apps/portal/src/lib/i18n.test.ts
+++ b/apps/portal/src/lib/i18n.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getMessages, getSafeLocale, isLocale, locales } from "@/lib/i18n";
+
+describe("i18n", () => {
+  it("exposes supported locales", () => {
+    expect(locales).toContain("en");
+    expect(locales).toContain("nl");
+  });
+
+  it("validates locales", () => {
+    expect(isLocale("en")).toBe(true);
+    expect(isLocale("nl")).toBe(true);
+    expect(isLocale("fr")).toBe(false);
+  });
+
+  it("returns messages for a locale", () => {
+    const messages = getMessages("en");
+
+    expect(messages.nav.brand).toBeTypeOf("string");
+    expect(messages.home.stats.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a safe locale", () => {
+    expect(getSafeLocale("nl")).toBe("nl");
+    expect(getSafeLocale("fr")).toBe("en");
+    expect(getSafeLocale()).toBe("en");
+  });
+});

--- a/apps/portal/src/lib/i18n.ts
+++ b/apps/portal/src/lib/i18n.ts
@@ -1,0 +1,41 @@
+import { en } from "@/locales/en";
+import { nl } from "@/locales/nl";
+
+/**
+ * Supported locale codes.
+ */
+export const locales = ["en", "nl"] as const;
+
+/**
+ * Union type of supported locales.
+ */
+export type Locale = (typeof locales)[number];
+
+const messages = {
+  en,
+  nl
+} satisfies Record<Locale, typeof en>;
+
+/**
+ * Determine whether a locale is supported.
+ */
+export function isLocale(value: string): value is Locale {
+  return locales.includes(value as Locale);
+}
+
+/**
+ * Get localized copy for the provided locale.
+ */
+export function getMessages(locale: Locale) {
+  return messages[locale];
+}
+
+/**
+ * Select a safe locale fallback.
+ */
+export function getSafeLocale(value?: string): Locale {
+  if (value && isLocale(value)) {
+    return value;
+  }
+  return "en";
+}

--- a/apps/portal/src/lib/supabase/queries.ts
+++ b/apps/portal/src/lib/supabase/queries.ts
@@ -1,0 +1,27 @@
+import type { HeroListing } from "@/data/hero";
+import type { Locale } from "@/lib/i18n";
+import { getHeroListings } from "@/data/hero";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+/**
+ * Fetch hero listings from a public view, falling back to locale content.
+ */
+export async function fetchHeroListings(locale: Locale): Promise<HeroListing[]> {
+  const supabase = createSupabaseServerClient();
+
+  if (!supabase) {
+    return getHeroListings(locale);
+  }
+
+  const { data, error } = await supabase
+    .schema("public")
+    .from("hero_listings_view")
+    .select("id,title,team,location,type,summary")
+    .order("id");
+
+  if (error || !data) {
+    return getHeroListings(locale);
+  }
+
+  return data;
+}

--- a/apps/portal/src/lib/supabase/server.ts
+++ b/apps/portal/src/lib/supabase/server.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import { createClient } from "@supabase/supabase-js";
+
+/**
+ * Build a Supabase server client using environment configuration.
+ */
+export function createSupabaseServerClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    return null;
+  }
+
+  return createClient(url, key, {
+    auth: {
+      persistSession: false
+    }
+  });
+}

--- a/apps/portal/src/lib/utils.ts
+++ b/apps/portal/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merge Tailwind class names with conditional support.
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/portal/src/locales/en.ts
+++ b/apps/portal/src/locales/en.ts
@@ -1,0 +1,132 @@
+/**
+ * English copy for the portal app.
+ */
+export const en = {
+  languageLabel: "English",
+  nav: {
+    brand: "Hero Portal",
+    primaryLinks: [
+      { href: "/en", label: "Hero listings" },
+      { href: "/en/jobs", label: "Featured roles" },
+      { href: "/en/employer", label: "Employer hub" }
+    ],
+    cta: "Start your match"
+  },
+  footer: {
+    title: "Talent constellation",
+    description: "Aligning heroic careers with mission-driven teams.",
+    secondary: "Crafted with trust-centric hiring."
+  },
+  home: {
+    heroTitle: "Discover roles built for hero impact",
+    heroSubtitle: "Curated mission-critical openings with transparent timelines.",
+    heroCta: "Explore open missions",
+    heroTag: "Trusted by mission operators",
+    heroListingsTitle: "Priority hero listings",
+    heroListingsSubtitle: "Roles vetted for clarity, growth, and mission scope.",
+    highlightTitle: "Why heroes choose this portal",
+    highlightSubtitle: "Recruitment experiences shaped around clarity and care.",
+    stats: [
+      { label: "Active missions", value: "124" },
+      { label: "Hiring squads", value: "42" },
+      { label: "Avg. time-to-match", value: "12 days" }
+    ],
+    highlights: [
+      {
+        title: "Clear mission briefs",
+        description: "Structured role briefs and outcomes before interviews."
+      },
+      {
+        title: "Transparent compensation",
+        description: "Published salary bands and growth paths for every opening."
+      },
+      {
+        title: "Guided onboarding",
+        description: "Partnered recruiters coordinate every launch step."
+      }
+    ]
+  },
+  jobs: {
+    title: "Featured hero roles",
+    subtitle: "Immediate-impact roles aligned with your specialty.",
+    filtersLabel: "Role focus",
+    filters: ["Leadership", "Operations", "Engineering", "Design"],
+    listings: [
+      {
+        id: "mission-aurora",
+        title: "Mission Strategy Lead",
+        team: "Aurora Defense",
+        location: "Amsterdam, NL",
+        type: "Hybrid",
+        summary: "Direct multi-team mission planning and field readiness."
+      },
+      {
+        id: "signal-nova",
+        title: "Signal Platform Engineer",
+        team: "Nova Orbit",
+        location: "Remote",
+        type: "Remote",
+        summary: "Build secure comms infrastructure for hero teams."
+      },
+      {
+        id: "atlas-ops",
+        title: "Operations Captain",
+        team: "Atlas Response",
+        location: "Utrecht, NL",
+        type: "On-site",
+        summary: "Coordinate field logistics and escalation flows."
+      }
+    ]
+  },
+  jobDetail: {
+    title: "Role brief",
+    sections: {
+      mission: "Mission",
+      outcomes: "Key outcomes",
+      traits: "Ideal hero profile"
+    },
+    actions: {
+      primary: "Request intro",
+      secondary: "Share role"
+    },
+    outcomes: [
+      "Launch mission within 30 days",
+      "Establish weekly alignment rituals",
+      "Deliver first mission debrief"
+    ],
+    traits: [
+      "Mission-first mindset",
+      "Clear cross-team communication",
+      "Comfort with rapid escalation"
+    ]
+  },
+  employer: {
+    title: "Employer command center",
+    subtitle: "Monitor hiring missions and hero readiness in one place.",
+    pipelineTitle: "Mission pipeline",
+    pipelineSubtitle: "Real-time status of hero onboarding.",
+    pipeline: [
+      { stage: "Sourced", value: "28" },
+      { stage: "Screened", value: "14" },
+      { stage: "Final briefing", value: "5" }
+    ],
+    actions: {
+      primary: "Publish new mission",
+      secondary: "Review shortlisted heroes"
+    }
+  },
+  loading: {
+    title: "Synchronizing mission data",
+    subtitle: "Refreshing hero intel for you."
+  },
+  error: {
+    title: "Mission control disruption",
+    subtitle: "We could not load this view. Please retry.",
+    action: "Retry"
+  },
+  notFound: {
+    title: "Signal lost",
+    subtitle: "This mission route could not be found.",
+    action: "Return home"
+  }
+} as const;

--- a/apps/portal/src/locales/nl.ts
+++ b/apps/portal/src/locales/nl.ts
@@ -1,0 +1,132 @@
+/**
+ * Dutch copy for the portal app.
+ */
+export const nl = {
+  languageLabel: "Nederlands",
+  nav: {
+    brand: "Hero Portaal",
+    primaryLinks: [
+      { href: "/nl", label: "Hero vacatures" },
+      { href: "/nl/jobs", label: "Toprollen" },
+      { href: "/nl/employer", label: "Werkgever hub" }
+    ],
+    cta: "Start je match"
+  },
+  footer: {
+    title: "Talentconstellatie",
+    description: "We koppelen hero-carrières aan missiegedreven teams.",
+    secondary: "Gemaakt voor transparante werving."
+  },
+  home: {
+    heroTitle: "Ontdek rollen met hero-impact",
+    heroSubtitle: "Geselecteerde missies met duidelijke tijdlijnen.",
+    heroCta: "Bekijk open missies",
+    heroTag: "Vertrouwd door mission operators",
+    heroListingsTitle: "Prioritaire hero vacatures",
+    heroListingsSubtitle: "Rollen met heldere scope en groei.",
+    highlightTitle: "Waarom heroes dit portaal kiezen",
+    highlightSubtitle: "Werving met focus op duidelijkheid en zorg.",
+    stats: [
+      { label: "Actieve missies", value: "124" },
+      { label: "Hiring squads", value: "42" },
+      { label: "Gem. time-to-match", value: "12 dagen" }
+    ],
+    highlights: [
+      {
+        title: "Heldere missiebriefings",
+        description: "Gestructureerde rolbriefings en outcomes voor interviews."
+      },
+      {
+        title: "Transparante beloning",
+        description: "Publicatie van salarisschalen en groeipaden."
+      },
+      {
+        title: "Begeleide onboarding",
+        description: "Recruiters coördineren elke startstap."
+      }
+    ]
+  },
+  jobs: {
+    title: "Uitgelichte hero rollen",
+    subtitle: "Directe impactrollen afgestemd op jouw expertise.",
+    filtersLabel: "Rol focus",
+    filters: ["Leiderschap", "Operations", "Engineering", "Design"],
+    listings: [
+      {
+        id: "mission-aurora",
+        title: "Mission Strategy Lead",
+        team: "Aurora Defense",
+        location: "Amsterdam, NL",
+        type: "Hybride",
+        summary: "Leid missiplanning en team readiness."
+      },
+      {
+        id: "signal-nova",
+        title: "Signal Platform Engineer",
+        team: "Nova Orbit",
+        location: "Remote",
+        type: "Remote",
+        summary: "Bouw veilige communicatie voor hero teams."
+      },
+      {
+        id: "atlas-ops",
+        title: "Operations Captain",
+        team: "Atlas Response",
+        location: "Utrecht, NL",
+        type: "On-site",
+        summary: "Coördineer veldlogistiek en escalaties."
+      }
+    ]
+  },
+  jobDetail: {
+    title: "Rolbrief",
+    sections: {
+      mission: "Missie",
+      outcomes: "Belangrijkste outcomes",
+      traits: "Ideaal hero profiel"
+    },
+    actions: {
+      primary: "Vraag introductie",
+      secondary: "Deel rol"
+    },
+    outcomes: [
+      "Start missie binnen 30 dagen",
+      "Stel wekelijkse alignment rituelen op",
+      "Lever eerste missie debrief"
+    ],
+    traits: [
+      "Missie-first mindset",
+      "Heldere teamcommunicatie",
+      "Comfortabel met escalatie"
+    ]
+  },
+  employer: {
+    title: "Werkgever command center",
+    subtitle: "Volg hiring missies en hero readiness centraal.",
+    pipelineTitle: "Missiepijplijn",
+    pipelineSubtitle: "Realtime status van hero onboarding.",
+    pipeline: [
+      { stage: "Gesourced", value: "28" },
+      { stage: "Gescreend", value: "14" },
+      { stage: "Final briefing", value: "5" }
+    ],
+    actions: {
+      primary: "Publiceer nieuwe missie",
+      secondary: "Bekijk shortlist"
+    }
+  },
+  loading: {
+    title: "Missiedata synchroniseren",
+    subtitle: "Hero-informatie wordt geladen."
+  },
+  error: {
+    title: "Storing in mission control",
+    subtitle: "We konden dit scherm niet laden. Probeer opnieuw.",
+    action: "Probeer opnieuw"
+  },
+  notFound: {
+    title: "Signaal verloren",
+    subtitle: "Deze missie-route bestaat niet.",
+    action: "Terug naar start"
+  }
+} as const;

--- a/apps/portal/src/styles/globals.css
+++ b/apps/portal/src/styles/globals.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-slate-950 text-white min-h-screen antialiased;
+  background-image: radial-gradient(circle at top, rgba(79, 70, 229, 0.35), transparent 45%),
+    radial-gradient(circle at 20% 20%, rgba(14, 116, 144, 0.35), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(14, 116, 144, 0.25), transparent 35%);
+}
+
+main {
+  @apply relative z-10;
+}
+
+.glass-panel {
+  @apply bg-glass/30 border border-glass-border shadow-glass backdrop-blur-glass;
+}

--- a/apps/portal/tailwind.config.ts
+++ b/apps/portal/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        glass: "rgba(255, 255, 255, 0.7)",
+        "glass-border": "rgba(148, 163, 184, 0.2)",
+        ink: "#0f172a",
+        accent: "#4f46e5"
+      },
+      boxShadow: {
+        glass: "0 20px 60px -40px rgba(15, 23, 42, 0.6)",
+        glow: "0 0 50px rgba(99, 102, 241, 0.25)"
+      },
+      backdropBlur: {
+        glass: "18px"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../packages/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "src", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/lib/**/*.ts", "src/data/**/*.ts"],
+      thresholds: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80
+      }
+    }
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide two App Router Next.js apps (`apps/portal` and `apps/jobs`) as localized, server-first recruitment experiences using TypeScript and Tailwind. 
- Prefer server-side data flows and reuseable UI so pages render as Server Components by default and avoid client-side DB calls. 
- Ship minimal, accessible recruitment pages (listings, detail, employer dashboard) with shared layout, error, and loading states and no hard-coded strings in components. 

### Description
- Scaffolds two apps with configs and deps (`package.json`, `next.config.mjs`, `tsconfig.json`, `tailwind.config.ts`, `postcss.config.js`, global styles) and a feature-based src layout under `src/app`, components, `lib`, `data`, and `locales`. 
- Adds localization infrastructure and copy in English and Dutch (`src/locales/en.ts`, `src/locales/nl.ts`) with `src/lib/i18n.ts` helpers (`locales`, `isLocale`, `getMessages`, `getSafeLocale`) used across layouts and components. 
- Implements server-side Supabase helpers (`createSupabaseServerClient`) and public-read query wrappers (`fetchHeroListings`, `fetchRoleListings`) that fall back to embedded locale data, plus typed `HeroListing`/`RoleListing` data utilities. 
- Adds UI primitives and pages including a Radix `Slot`-backed `Button`, `FadeIn` motion wrapper (Framer Motion), `HeroCard`/`RoleCard`, metric/highlight cards, shared `SiteHeader`/`SiteFooter`, locale layouts, pages for listings, detail, and employer/dashboard, and accessible loading/error/not-found states. 

### Testing
- Added Vitest configuration files (`vitest.config.ts`) with coverage `v8` provider and thresholds set to 80% for statements, branches, functions, and lines. 
- Added unit tests for i18n and sample data helpers (`src/lib/i18n.test.ts`, `src/data/*.test.ts`) in both apps. 
- Tests were not executed in this environment because `pnpm install` failed due to a network restriction when fetching pnpm, so automated test run is pending (install/network issue).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e2c98fe0083209d8a1c3a564cd8bd)