### PR TITLE
feat(lib,ui): add @bluehero/lib and @bluehero/ui with recruitment primitives and typed Supabase helpers

### DIFF
--- a/packages/eslint-config/nextjs.cjs
+++ b/packages/eslint-config/nextjs.cjs
@@ -13,12 +13,25 @@ module.exports = {
             message: "Import shared code from packages instead of other apps."
           },
           {
+            group: [
+              "../packages/*",
+              "../../packages/*",
+              "../../../packages/*",
+              "../../../../packages/*"
+            ],
+            message: "Apps must import shared code from @bluehero/* packages."
+          },
+          {
             group: ["../supabase/*", "../../supabase/*", "../../../supabase/*"],
             message: "Access Supabase via packages instead of direct workspace imports."
           },
           {
             group: ["../tests/*", "../../tests/*", "../../../tests/*"],
             message: "Tests are not allowed as runtime dependencies."
+          },
+          {
+            group: ["@hero/*"],
+            message: "Apps must import shared code from @bluehero/* packages."
           }
         ]
       }

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -1,0 +1,40 @@
+# @bluehero/lib
+
+Typed domain models, Supabase query wrappers, and shared utilities for BlueHero applications.
+
+## Exports
+
+### Models
+- `ApplicationInput`
+- `ApplicationResult`
+- `CandidatePipelineSummary`
+- `EmploymentType`
+- `JobDetail`
+- `JobListing`
+- `JobStatus`
+- `WithdrawalResult`
+
+### Constants
+- `CANDIDATE_PIPELINE_VIEW`
+- `JOB_DETAIL_VIEW`
+- `JOB_LISTINGS_VIEW`
+- `RECRUITMENT_SCHEMA`
+- `SUBMIT_APPLICATION_FUNCTION`
+- `WITHDRAW_APPLICATION_FUNCTION`
+
+### Queries
+- `fetchJobListings`
+- `fetchJobDetailBySlug`
+- `submitApplication`
+- `withdrawApplication`
+- `JobListingFilters`
+
+### Utilities
+- `formatCurrencyRange`
+- `formatLocation`
+- `formatRelativeDate`
+- `isNonEmptyString`
+- `buildPaginationRange`
+- `unwrapSupabaseResult`
+- `SupabaseErrorShape`
+- `SupabaseResponse`

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@bluehero/lib",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.12",
+    "@vitest/coverage-v8": "^2.0.5",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  }
+}

--- a/packages/lib/src/constants.ts
+++ b/packages/lib/src/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Canonical schema name for Supabase recruitment data.
+ */
+export const RECRUITMENT_SCHEMA = "recruitment";
+
+/**
+ * Public views used for read-only queries.
+ */
+export const JOB_LISTINGS_VIEW = "job_listings_view";
+export const JOB_DETAIL_VIEW = "job_detail_view";
+export const CANDIDATE_PIPELINE_VIEW = "candidate_pipeline_view";
+
+/**
+ * Public RPC functions used for write operations with RLS enforcement.
+ */
+export const SUBMIT_APPLICATION_FUNCTION = "submit_application";
+export const WITHDRAW_APPLICATION_FUNCTION = "withdraw_application";

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @bluehero/lib exports typed domain models, Supabase query helpers, and shared utilities.
+ */
+
+export type {
+  ApplicationInput,
+  ApplicationResult,
+  CandidatePipelineSummary,
+  EmploymentType,
+  JobDetail,
+  JobListing,
+  JobStatus,
+  WithdrawalResult
+} from "./models";
+
+export {
+  CANDIDATE_PIPELINE_VIEW,
+  JOB_DETAIL_VIEW,
+  JOB_LISTINGS_VIEW,
+  RECRUITMENT_SCHEMA,
+  SUBMIT_APPLICATION_FUNCTION,
+  WITHDRAW_APPLICATION_FUNCTION
+} from "./constants";
+
+export type { JobListingFilters } from "./queries/jobs";
+export { fetchJobDetailBySlug, fetchJobListings } from "./queries/jobs";
+
+export { submitApplication, withdrawApplication } from "./queries/applications";
+
+export { formatCurrencyRange, formatLocation, formatRelativeDate } from "./utils/formatters";
+export { isNonEmptyString } from "./utils/guards";
+export { buildPaginationRange } from "./utils/pagination";
+export type { SupabaseErrorShape, SupabaseResponse } from "./utils/result";
+export { unwrapSupabaseResult } from "./utils/result";

--- a/packages/lib/src/models.ts
+++ b/packages/lib/src/models.ts
@@ -1,0 +1,56 @@
+/**
+ * Domain models for recruitment workflows.
+ */
+
+export type EmploymentType = "full-time" | "part-time" | "contract" | "intern";
+
+export type JobStatus = "open" | "paused" | "closed";
+
+export interface JobListing {
+  id: string;
+  title: string;
+  slug: string;
+  department: string;
+  location: string;
+  employmentType: EmploymentType;
+  salaryRange: string | null;
+  postedAt: string;
+  status: JobStatus;
+  highlights: string[];
+}
+
+export interface JobDetail extends JobListing {
+  description: string;
+  responsibilities: string[];
+  qualifications: string[];
+  benefits: string[];
+}
+
+export interface CandidatePipelineSummary {
+  jobId: string;
+  jobTitle: string;
+  stageCounts: Record<string, number>;
+  totalCandidates: number;
+  lastUpdatedAt: string;
+}
+
+export interface ApplicationInput {
+  jobId: string;
+  fullName: string;
+  email: string;
+  resumeUrl: string;
+  portfolioUrl?: string | null;
+  coverLetter?: string | null;
+}
+
+export interface ApplicationResult {
+  applicationId: string;
+  status: "received" | "screening" | "interview" | "offer" | "hired" | "rejected";
+  submittedAt: string;
+}
+
+export interface WithdrawalResult {
+  applicationId: string;
+  status: "withdrawn";
+  withdrawnAt: string;
+}

--- a/packages/lib/src/queries/applications.ts
+++ b/packages/lib/src/queries/applications.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  RECRUITMENT_SCHEMA,
+  SUBMIT_APPLICATION_FUNCTION,
+  WITHDRAW_APPLICATION_FUNCTION
+} from "../constants";
+import type {
+  ApplicationInput,
+  ApplicationResult,
+  WithdrawalResult
+} from "../models";
+import { unwrapSupabaseResult } from "../utils/result";
+
+/**
+ * Submit a new application via a secured RPC function.
+ */
+export const submitApplication = async (
+  client: SupabaseClient,
+  payload: ApplicationInput
+): Promise<ApplicationResult> => {
+  const response = await client
+    .schema(RECRUITMENT_SCHEMA)
+    .rpc(SUBMIT_APPLICATION_FUNCTION, {
+      job_id: payload.jobId,
+      full_name: payload.fullName,
+      email: payload.email,
+      resume_url: payload.resumeUrl,
+      portfolio_url: payload.portfolioUrl ?? null,
+      cover_letter: payload.coverLetter ?? null
+    });
+
+  return unwrapSupabaseResult(response, "submitApplication");
+};
+
+/**
+ * Withdraw a candidate application using a public RPC function.
+ */
+export const withdrawApplication = async (
+  client: SupabaseClient,
+  applicationId: string
+): Promise<WithdrawalResult> => {
+  const response = await client
+    .schema(RECRUITMENT_SCHEMA)
+    .rpc(WITHDRAW_APPLICATION_FUNCTION, {
+      application_id: applicationId
+    });
+
+  return unwrapSupabaseResult(response, "withdrawApplication");
+};

--- a/packages/lib/src/queries/jobs.ts
+++ b/packages/lib/src/queries/jobs.ts
@@ -1,0 +1,56 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import {
+  JOB_DETAIL_VIEW,
+  JOB_LISTINGS_VIEW,
+  RECRUITMENT_SCHEMA
+} from "../constants";
+import type { JobDetail, JobListing, JobStatus } from "../models";
+import { unwrapSupabaseResult } from "../utils/result";
+
+export interface JobListingFilters {
+  status?: JobStatus[];
+  limit?: number;
+}
+
+/**
+ * Fetch job listings from the recruitment view.
+ */
+export const fetchJobListings = async (
+  client: SupabaseClient,
+  filters: JobListingFilters = {}
+): Promise<JobListing[]> => {
+  let query = client
+    .schema(RECRUITMENT_SCHEMA)
+    .from(JOB_LISTINGS_VIEW)
+    .select("*")
+    .order("posted_at", { ascending: false });
+
+  if (filters.status && filters.status.length > 0) {
+    query = query.in("status", filters.status);
+  }
+
+  if (filters.limit) {
+    query = query.limit(filters.limit);
+  }
+
+  const response = await query;
+  return unwrapSupabaseResult(response, "fetchJobListings");
+};
+
+/**
+ * Fetch a detailed job record by slug.
+ */
+export const fetchJobDetailBySlug = async (
+  client: SupabaseClient,
+  slug: string
+): Promise<JobDetail> => {
+  const response = await client
+    .schema(RECRUITMENT_SCHEMA)
+    .from(JOB_DETAIL_VIEW)
+    .select("*")
+    .eq("slug", slug)
+    .single();
+
+  return unwrapSupabaseResult(response, "fetchJobDetailBySlug");
+};

--- a/packages/lib/src/utils/formatters.test.ts
+++ b/packages/lib/src/utils/formatters.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCurrencyRange, formatLocation, formatRelativeDate } from "./formatters";
+
+describe("formatters", () => {
+  it("formats currency ranges", () => {
+    expect(formatCurrencyRange(120000, 140000)).toBe("$120,000 - $140,000");
+  });
+
+  it("formats locations", () => {
+    expect(formatLocation("Austin")).toBe("Austin");
+    expect(formatLocation("Austin", "TX")).toBe("Austin, TX");
+  });
+
+  it("formats relative dates", () => {
+    const now = new Date("2024-01-10T00:00:00.000Z");
+    expect(formatRelativeDate("2024-01-10T00:00:00.000Z", now)).toBe("Today");
+    expect(formatRelativeDate("2024-01-09T00:00:00.000Z", now)).toBe("1 day ago");
+    expect(formatRelativeDate("2024-01-05T00:00:00.000Z", now)).toBe("5 days ago");
+  });
+});

--- a/packages/lib/src/utils/formatters.ts
+++ b/packages/lib/src/utils/formatters.ts
@@ -1,0 +1,46 @@
+/**
+ * Format a currency string for compensation ranges.
+ */
+export const formatCurrencyRange = (
+  min: number,
+  max: number,
+  currency: string = "USD"
+): string => {
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0
+  });
+
+  return `${formatter.format(min)} - ${formatter.format(max)}`;
+};
+
+/**
+ * Normalize a location string for consistent display.
+ */
+export const formatLocation = (city: string, region?: string | null): string => {
+  if (!region) {
+    return city;
+  }
+
+  return `${city}, ${region}`;
+};
+
+/**
+ * Render an accessible relative time label.
+ */
+export const formatRelativeDate = (isoDate: string, now = new Date()): string => {
+  const date = new Date(isoDate);
+  const diffInMs = now.getTime() - date.getTime();
+  const diffInDays = Math.round(diffInMs / (1000 * 60 * 60 * 24));
+
+  if (diffInDays <= 0) {
+    return "Today";
+  }
+
+  if (diffInDays === 1) {
+    return "1 day ago";
+  }
+
+  return `${diffInDays} days ago`;
+};

--- a/packages/lib/src/utils/guards.test.ts
+++ b/packages/lib/src/utils/guards.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { isNonEmptyString } from "./guards";
+
+describe("isNonEmptyString", () => {
+  it("validates strings", () => {
+    expect(isNonEmptyString("hello")).toBe(true);
+    expect(isNonEmptyString(" ")).toBe(false);
+    expect(isNonEmptyString(12)).toBe(false);
+  });
+});

--- a/packages/lib/src/utils/guards.ts
+++ b/packages/lib/src/utils/guards.ts
@@ -1,0 +1,6 @@
+/**
+ * Ensure a string is not empty after trimming whitespace.
+ */
+export const isNonEmptyString = (value: unknown): value is string => {
+  return typeof value === "string" && value.trim().length > 0;
+};

--- a/packages/lib/src/utils/pagination.test.ts
+++ b/packages/lib/src/utils/pagination.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPaginationRange } from "./pagination";
+
+describe("buildPaginationRange", () => {
+  it("builds a compact range", () => {
+    expect(buildPaginationRange(5, 10)).toEqual([1, "…", 4, 5, 6, "…", 10]);
+  });
+
+  it("handles short ranges", () => {
+    expect(buildPaginationRange(2, 3)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/lib/src/utils/pagination.ts
+++ b/packages/lib/src/utils/pagination.ts
@@ -1,0 +1,23 @@
+/**
+ * Build a compact pagination range with ellipses.
+ */
+export const buildPaginationRange = (
+  currentPage: number,
+  totalPages: number
+): Array<number | "…"> => {
+  const clampedCurrent = Math.max(1, Math.min(currentPage, totalPages));
+  const range: Array<number | "…"> = [];
+
+  for (let page = 1; page <= totalPages; page += 1) {
+    const isEdge = page === 1 || page === totalPages;
+    const isNearCurrent = Math.abs(page - clampedCurrent) <= 1;
+
+    if (isEdge || isNearCurrent) {
+      range.push(page);
+    } else if (range[range.length - 1] !== "…") {
+      range.push("…");
+    }
+  }
+
+  return range;
+};

--- a/packages/lib/src/utils/result.test.ts
+++ b/packages/lib/src/utils/result.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { unwrapSupabaseResult } from "./result";
+
+describe("unwrapSupabaseResult", () => {
+  it("returns data when present", () => {
+    const response = { data: { ok: true }, error: null };
+    expect(unwrapSupabaseResult(response, "test")).toEqual({ ok: true });
+  });
+
+  it("throws on errors", () => {
+    const response = { data: null, error: { message: "boom" } };
+    expect(() => unwrapSupabaseResult(response, "test")).toThrow(
+      "Supabase test failed: boom"
+    );
+  });
+
+  it("throws when data is null", () => {
+    const response = { data: null, error: null };
+    expect(() => unwrapSupabaseResult(response, "empty")).toThrow(
+      "Supabase empty returned no data."
+    );
+  });
+});

--- a/packages/lib/src/utils/result.ts
+++ b/packages/lib/src/utils/result.ts
@@ -1,0 +1,31 @@
+export type SupabaseErrorShape = {
+  message: string;
+  details?: string | null;
+  hint?: string | null;
+  code?: string | null;
+};
+
+export type SupabaseResponse<T> = {
+  data: T | null;
+  error: SupabaseErrorShape | null;
+  status?: number;
+};
+
+/**
+ * Normalize Supabase responses, raising a descriptive error when needed.
+ */
+export const unwrapSupabaseResult = <T>(
+  response: SupabaseResponse<T>,
+  context: string
+): T => {
+  if (response.error) {
+    const details = response.error.details ? ` (${response.error.details})` : "";
+    throw new Error(`Supabase ${context} failed: ${response.error.message}${details}`);
+  }
+
+  if (response.data === null) {
+    throw new Error(`Supabase ${context} returned no data.`);
+  }
+
+  return response.data;
+};

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      lines: 80,
+      functions: 80,
+      branches: 80,
+      statements: 80,
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.test.ts", "src/index.ts"]
+    }
+  }
+});

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,23 @@
+# @bluehero/ui
+
+ShadCN-inspired primitives and recruitment UI components styled with TailwindCSS and Framer Motion.
+
+## Exports
+
+### Utilities
+- `cn`
+
+### Primitives
+- `Badge`
+- `Button`
+- `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, `CardFooter`
+- `Input`
+- `Skeleton`
+- `Textarea`
+
+### Recruitment components
+- `JobCard`
+- `PipelineSummary`
+- `RecruitmentLoadingState`
+- `RecruitmentErrorState`
+- `MotionSurface`

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@bluehero/ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "src"
+  ],
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.1.0",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.5.4",
+    "tailwind-merge": "^2.5.2"
+  },
+  "peerDependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitest/coverage-v8": "^2.0.5",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  }
+}

--- a/packages/ui/src/components/primitives/badge.tsx
+++ b/packages/ui/src/components/primitives/badge.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import { cn } from "../../lib/cn";
+
+export type BadgeVariant = "soft" | "solid";
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+const badgeVariants: Record<BadgeVariant, string> = {
+  soft: "bg-slate-900/5 text-slate-700",
+  solid: "bg-slate-900 text-white"
+};
+
+/**
+ * ShadCN-inspired badge for metadata.
+ */
+export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant = "soft", ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(
+        "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
+        badgeVariants[variant],
+        className
+      )}
+      {...props}
+    />
+  )
+);
+
+Badge.displayName = "Badge";

--- a/packages/ui/src/components/primitives/button.test.tsx
+++ b/packages/ui/src/components/primitives/button.test.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Button } from "./button";
+
+describe("Button", () => {
+  it("renders default button styles", () => {
+    const markup = renderToStaticMarkup(<Button>Apply</Button>);
+    expect(markup).toContain("rounded-full");
+    expect(markup).toContain("Apply");
+  });
+
+  it("renders ghost variant", () => {
+    const markup = renderToStaticMarkup(
+      <Button variant="ghost" size="sm">
+        Details
+      </Button>
+    );
+    expect(markup).toContain("bg-transparent");
+    expect(markup).toContain("Details");
+  });
+});

--- a/packages/ui/src/components/primitives/button.tsx
+++ b/packages/ui/src/components/primitives/button.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+
+import { cn } from "../../lib/cn";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "bg-white/70 text-slate-900 shadow-sm ring-1 ring-white/40 hover:bg-white/90",
+  secondary:
+    "bg-slate-900/5 text-slate-900 ring-1 ring-slate-900/10 hover:bg-slate-900/10",
+  ghost: "bg-transparent text-slate-900 hover:bg-slate-900/5"
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "h-8 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-base"
+};
+
+/**
+ * ShadCN-inspired button primitive.
+ */
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      asChild = false,
+      className,
+      variant = "primary",
+      size = "md",
+      type = "button",
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : "button";
+
+    return (
+      <Comp
+        className={cn(
+          "inline-flex items-center justify-center gap-2 rounded-full font-medium transition duration-200",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-900/20",
+          "disabled:pointer-events-none disabled:opacity-50",
+          variantClasses[variant],
+          sizeClasses[size],
+          className
+        )}
+        ref={ref}
+        type={type}
+        {...props}
+      />
+    );
+  }
+);
+
+Button.displayName = "Button";

--- a/packages/ui/src/components/primitives/card.tsx
+++ b/packages/ui/src/components/primitives/card.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+
+import { cn } from "../../lib/cn";
+
+/**
+ * ShadCN-inspired card primitive for glass surfaces.
+ */
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-3xl border border-white/40 bg-white/60 p-6 shadow-[0_25px_60px_-40px_rgba(15,23,42,0.4)]",
+        "backdrop-blur-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex flex-col gap-2", className)} {...props} />
+));
+
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-lg font-semibold text-slate-900", className)} {...props} />
+));
+
+CardTitle.displayName = "CardTitle";
+
+export const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-slate-600", className)} {...props} />
+));
+
+CardDescription.displayName = "CardDescription";
+
+export const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("mt-4 space-y-3", className)} {...props} />
+));
+
+CardContent.displayName = "CardContent";
+
+export const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("mt-6 flex items-center gap-3", className)} {...props} />
+));
+
+CardFooter.displayName = "CardFooter";

--- a/packages/ui/src/components/primitives/input.tsx
+++ b/packages/ui/src/components/primitives/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "../../lib/cn";
+
+/**
+ * Glass input field primitive.
+ */
+export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type = "text", ...props }, ref) => (
+    <input
+      ref={ref}
+      type={type}
+      className={cn(
+        "h-11 w-full rounded-2xl border border-white/40 bg-white/70 px-4 text-sm text-slate-900",
+        "placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900/10",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+
+Input.displayName = "Input";

--- a/packages/ui/src/components/primitives/primitives.test.tsx
+++ b/packages/ui/src/components/primitives/primitives.test.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Badge } from "./badge";
+import { Card, CardContent, CardHeader, CardTitle } from "./card";
+import { Input } from "./input";
+import { Skeleton } from "./skeleton";
+import { Textarea } from "./textarea";
+
+describe("primitives", () => {
+  it("renders badge variants", () => {
+    const markup = renderToStaticMarkup(<Badge variant="solid">New</Badge>);
+    expect(markup).toContain("New");
+    expect(markup).toContain("bg-slate-900");
+  });
+
+  it("renders card sections", () => {
+    const markup = renderToStaticMarkup(
+      <Card>
+        <CardHeader>
+          <CardTitle>Title</CardTitle>
+        </CardHeader>
+        <CardContent>Content</CardContent>
+      </Card>
+    );
+
+    expect(markup).toContain("Title");
+    expect(markup).toContain("Content");
+  });
+
+  it("renders input, textarea, and skeleton", () => {
+    const markup = renderToStaticMarkup(
+      <div>
+        <Input placeholder="Email" />
+        <Textarea placeholder="Message" />
+        <Skeleton className="h-4 w-4" />
+      </div>
+    );
+
+    expect(markup).toContain("placeholder=\"Email\"");
+    expect(markup).toContain("placeholder=\"Message\"");
+    expect(markup).toContain("animate-pulse");
+  });
+});

--- a/packages/ui/src/components/primitives/skeleton.tsx
+++ b/packages/ui/src/components/primitives/skeleton.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "../../lib/cn";
+
+/**
+ * Animated skeleton block for loading states.
+ */
+export const Skeleton = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("animate-pulse rounded-2xl bg-slate-900/5", className)}
+      {...props}
+    />
+  )
+);
+
+Skeleton.displayName = "Skeleton";

--- a/packages/ui/src/components/primitives/textarea.tsx
+++ b/packages/ui/src/components/primitives/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "../../lib/cn";
+
+/**
+ * Glass textarea primitive.
+ */
+export const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, rows = 4, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    rows={rows}
+    className={cn(
+      "w-full rounded-2xl border border-white/40 bg-white/70 px-4 py-3 text-sm text-slate-900",
+      "placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-900/10",
+      className
+    )}
+    {...props}
+  />
+));
+
+Textarea.displayName = "Textarea";

--- a/packages/ui/src/components/recruitment/error-state.tsx
+++ b/packages/ui/src/components/recruitment/error-state.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "../primitives/card";
+import { cn } from "../../lib/cn";
+
+export interface RecruitmentErrorStateProps {
+  title?: string;
+  description: string;
+  className?: string;
+  action?: React.ReactNode;
+}
+
+/**
+ * Error state card for recruitment surfaces.
+ */
+export const RecruitmentErrorState = ({
+  title = "Something went wrong",
+  description,
+  className,
+  action
+}: RecruitmentErrorStateProps) => (
+  <Card className={cn("space-y-4 border-rose-100 bg-rose-50/60", className)}>
+    <CardHeader>
+      <CardTitle className="text-rose-900">{title}</CardTitle>
+    </CardHeader>
+    <CardContent className="space-y-4">
+      <p className="text-sm text-rose-700">{description}</p>
+      {action}
+    </CardContent>
+  </Card>
+);

--- a/packages/ui/src/components/recruitment/job-card.test.tsx
+++ b/packages/ui/src/components/recruitment/job-card.test.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { JobCard } from "./job-card";
+
+describe("JobCard", () => {
+  it("renders job details", () => {
+    const markup = renderToStaticMarkup(
+      <JobCard
+        title="Senior UX Designer"
+        department="Design"
+        location="Remote"
+        employmentType="Full-time"
+        postedLabel="2 days ago"
+        salaryRange="$120k - $140k"
+        highlights={["Crafted premium UI", "Partnered with product"]}
+      />
+    );
+
+    expect(markup).toContain("Senior UX Designer");
+    expect(markup).toContain("Design");
+    expect(markup).toContain("Crafted premium UI");
+  });
+});

--- a/packages/ui/src/components/recruitment/job-card.tsx
+++ b/packages/ui/src/components/recruitment/job-card.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+
+import { Badge } from "../primitives/badge";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "../primitives/card";
+import { cn } from "../../lib/cn";
+
+export interface JobCardProps {
+  title: string;
+  department: string;
+  location: string;
+  employmentType: string;
+  postedLabel: string;
+  statusLabel?: string;
+  salaryRange?: string | null;
+  highlights?: string[];
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Recruitment-focused job card for role listings.
+ */
+export const JobCard = ({
+  title,
+  department,
+  location,
+  employmentType,
+  postedLabel,
+  statusLabel,
+  salaryRange,
+  highlights = [],
+  actions,
+  className
+}: JobCardProps) => (
+  <Card className={cn("space-y-4", className)}>
+    <CardHeader>
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge>{department}</Badge>
+        <Badge variant="soft">{employmentType}</Badge>
+        {statusLabel ? <Badge variant="solid">{statusLabel}</Badge> : null}
+      </div>
+      <CardTitle>{title}</CardTitle>
+      <CardDescription>
+        {location} · {postedLabel}
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      {salaryRange ? (
+        <p className="text-sm text-slate-700">Compensation: {salaryRange}</p>
+      ) : null}
+      {highlights.length > 0 ? (
+        <ul className="list-disc space-y-1 pl-4 text-sm text-slate-600">
+          {highlights.map((highlight) => (
+            <li key={highlight}>{highlight}</li>
+          ))}
+        </ul>
+      ) : null}
+    </CardContent>
+    {actions ? <CardFooter className="justify-between">{actions}</CardFooter> : null}
+  </Card>
+);

--- a/packages/ui/src/components/recruitment/loading-state.tsx
+++ b/packages/ui/src/components/recruitment/loading-state.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import { Card, CardContent, CardHeader } from "../primitives/card";
+import { Skeleton } from "../primitives/skeleton";
+import { cn } from "../../lib/cn";
+
+export interface RecruitmentLoadingStateProps {
+  title?: string;
+  className?: string;
+}
+
+/**
+ * Loading state for recruitment surfaces.
+ */
+export const RecruitmentLoadingState = ({
+  title = "Loading roles",
+  className
+}: RecruitmentLoadingStateProps) => (
+  <Card className={cn("space-y-4", className)}>
+    <CardHeader>
+      <Skeleton className="h-4 w-32" />
+      <Skeleton className="h-6 w-2/3" />
+    </CardHeader>
+    <CardContent className="space-y-3">
+      <p className="text-sm text-slate-500">{title}</p>
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-4/6" />
+    </CardContent>
+  </Card>
+);

--- a/packages/ui/src/components/recruitment/motion-surface.tsx
+++ b/packages/ui/src/components/recruitment/motion-surface.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+
+import { cn } from "../../lib/cn";
+
+export interface MotionSurfaceProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+/**
+ * Client-only motion wrapper for subtle hover elevation.
+ */
+export const MotionSurface = ({ children, className, ...props }: MotionSurfaceProps) => (
+  <motion.div
+    className={cn("transition-transform", className)}
+    whileHover={{ y: -4 }}
+    transition={{ duration: 0.2, ease: "easeOut" }}
+    {...props}
+  >
+    {children}
+  </motion.div>
+);

--- a/packages/ui/src/components/recruitment/pipeline-summary.tsx
+++ b/packages/ui/src/components/recruitment/pipeline-summary.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+import { Badge } from "../primitives/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "../primitives/card";
+import { cn } from "../../lib/cn";
+
+export interface PipelineSummaryProps {
+  jobTitle: string;
+  totalCandidates: number;
+  stageCounts: Record<string, number>;
+  updatedLabel: string;
+  className?: string;
+}
+
+/**
+ * Snapshot card for candidate pipeline metrics.
+ */
+export const PipelineSummary = ({
+  jobTitle,
+  totalCandidates,
+  stageCounts,
+  updatedLabel,
+  className
+}: PipelineSummaryProps) => (
+  <Card className={cn("space-y-4", className)}>
+    <CardHeader>
+      <Badge variant="soft">Pipeline</Badge>
+      <CardTitle>{jobTitle}</CardTitle>
+      <p className="text-sm text-slate-500">Updated {updatedLabel}</p>
+    </CardHeader>
+    <CardContent className="space-y-3">
+      <p className="text-3xl font-semibold text-slate-900">{totalCandidates} candidates</p>
+      <div className="flex flex-wrap gap-2">
+        {Object.entries(stageCounts).map(([stage, count]) => (
+          <Badge key={stage}>{stage}: {count}</Badge>
+        ))}
+      </div>
+    </CardContent>
+  </Card>
+);

--- a/packages/ui/src/components/recruitment/recruitment-states.test.tsx
+++ b/packages/ui/src/components/recruitment/recruitment-states.test.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { MotionSurface } from "./motion-surface";
+import { PipelineSummary } from "./pipeline-summary";
+import { RecruitmentErrorState } from "./error-state";
+import { RecruitmentLoadingState } from "./loading-state";
+
+describe("recruitment states", () => {
+  it("renders loading state", () => {
+    const markup = renderToStaticMarkup(<RecruitmentLoadingState />);
+    expect(markup).toContain("Loading roles");
+  });
+
+  it("renders error state", () => {
+    const markup = renderToStaticMarkup(
+      <RecruitmentErrorState description="Please retry" />
+    );
+    expect(markup).toContain("Something went wrong");
+    expect(markup).toContain("Please retry");
+  });
+
+  it("renders pipeline summary", () => {
+    const markup = renderToStaticMarkup(
+      <PipelineSummary
+        jobTitle="Product Designer"
+        totalCandidates={12}
+        stageCounts={{ Screening: 5, Interview: 3 }}
+        updatedLabel="today"
+      />
+    );
+
+    expect(markup).toContain("Product Designer");
+    expect(markup).toContain("12 candidates");
+  });
+
+  it("wraps content with motion surface", () => {
+    const markup = renderToStaticMarkup(
+      <MotionSurface>
+        <div>Hover me</div>
+      </MotionSurface>
+    );
+
+    expect(markup).toContain("Hover me");
+  });
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,39 @@
+/**
+ * @bluehero/ui exports ShadCN-inspired primitives and recruitment UI components.
+ */
+
+export { cn } from "./lib/cn";
+
+export type { BadgeProps, BadgeVariant } from "./components/primitives/badge";
+export { Badge } from "./components/primitives/badge";
+
+export type { ButtonProps, ButtonSize, ButtonVariant } from "./components/primitives/button";
+export { Button } from "./components/primitives/button";
+
+export {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from "./components/primitives/card";
+
+export { Input } from "./components/primitives/input";
+export { Skeleton } from "./components/primitives/skeleton";
+export { Textarea } from "./components/primitives/textarea";
+
+export type { JobCardProps } from "./components/recruitment/job-card";
+export { JobCard } from "./components/recruitment/job-card";
+
+export type { RecruitmentErrorStateProps } from "./components/recruitment/error-state";
+export { RecruitmentErrorState } from "./components/recruitment/error-state";
+
+export type { RecruitmentLoadingStateProps } from "./components/recruitment/loading-state";
+export { RecruitmentLoadingState } from "./components/recruitment/loading-state";
+
+export type { PipelineSummaryProps } from "./components/recruitment/pipeline-summary";
+export { PipelineSummary } from "./components/recruitment/pipeline-summary";
+
+export type { MotionSurfaceProps } from "./components/recruitment/motion-surface";
+export { MotionSurface } from "./components/recruitment/motion-surface";

--- a/packages/ui/src/lib/cn.test.ts
+++ b/packages/ui/src/lib/cn.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "./cn";
+
+describe("cn", () => {
+  it("merges conditional classes", () => {
+    expect(cn("px-2", false, "py-1")).toBe("px-2 py-1");
+  });
+
+  it("resolves Tailwind conflicts", () => {
+    expect(cn("p-2", "p-4")).toBe("p-4");
+  });
+});

--- a/packages/ui/src/lib/cn.ts
+++ b/packages/ui/src/lib/cn.ts
@@ -1,0 +1,9 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Merge Tailwind class names with conditional logic.
+ */
+export const cn = (...inputs: Array<string | undefined | null | false>) => {
+  return twMerge(clsx(inputs));
+};

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "jsx": "preserve"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      lines: 80,
+      functions: 80,
+      branches: 80,
+      statements: 80,
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.test.*", "src/index.ts"]
+    }
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide shared, server-first building blocks for recruitment features: typed domain models, Supabase query wrappers, and UI primitives.
- Standardize visual language with ShadCN-inspired, Tailwind + Framer Motion components for a glassy, accessible recruitment surface.
- Enforce workspace import boundaries so apps consume shared code via `@bluehero/*` packages only.

### Description
- Add `@bluehero/lib` with typed models (`models.ts`), constants for Supabase schema/views/RPCs (`constants.ts`), query wrappers (`queries/jobs.ts`, `queries/applications.ts`), result handling and small utilities (`utils/*`), package exports (`src/index.ts`), TypeScript and `vitest` configs, and package manifest (`package.json`).
- Add `@bluehero/ui` with `cn` helper, ShadCN-style primitives (`Button`, `Card`, `Badge`, `Input`, `Textarea`, `Skeleton`), recruitment UI components (`JobCard`, `PipelineSummary`, `RecruitmentLoadingState`, `RecruitmentErrorState`, `MotionSurface`), package exports (`src/index.ts`), TypeScript and `vitest` configs, and package manifest (`package.json`).
- Documented exports in `packages/*/README.md` and wired package `exports` entries for better import ergonomics and boundaries.
- Tighten `packages/eslint-config/nextjs.cjs` to disallow direct imports from apps/supabase/tests and to require apps import shared code from `@bluehero/*` (also ban `@hero/*`).

### Testing
- Unit tests were added for both packages using `vitest` covering formatters, guards, pagination, result handling, and multiple UI primitives/components and the `cn` helper, with coverage thresholds configured at 80% in each package.
- No automated tests were executed as part of this rollout (test files and `vitest` configs are present but not run).
- CI/test run should be executed after publishing or installing deps to verify coverage and integration in consumer apps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e332d5c588320927d2efb6e6d2436)