### PR TITLE
test: add Vitest + RTL baselines and Playwright E2E scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ pnpm lint
 pnpm typecheck
 ```
 
+### Required command
+
+```bash
+turbo run build test lint
+```
+
 ### Tests
 
 ```bash

--- a/apps/jobs/package.json
+++ b/apps/jobs/package.json
@@ -22,16 +22,18 @@
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^20.14.12",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@vitest/coverage-v8": "^2.0.5",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4",
-    "vitest": "^2.0.5",
-    "@vitest/coverage-v8": "^2.0.5"
+    "vitest": "^2.0.5"
   }
 }

--- a/apps/jobs/src/components/ui/button.test.tsx
+++ b/apps/jobs/src/components/ui/button.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "@/components/ui/button";
+
+describe("Button", () => {
+  it("renders with ghost styling", () => {
+    render(<Button variant="ghost">View roles</Button>);
+
+    const button = screen.getByRole("button", { name: "View roles" });
+
+    expect(button).toHaveClass("border");
+  });
+});

--- a/apps/jobs/src/lib/supabase/queries.test.ts
+++ b/apps/jobs/src/lib/supabase/queries.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchRoleListings } from "@/lib/supabase/queries";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getRoleListings } from "@/data/roles";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn()
+}));
+
+vi.mock("@/data/roles", () => ({
+  getRoleListings: vi.fn(() => [
+    {
+      id: 1,
+      title: "Head of Talent",
+      team: "People",
+      location: "Remote",
+      type: "Full-time",
+      summary: "Guide the recruiting experience."
+    }
+  ])
+}));
+
+const mockedCreateSupabaseServerClient = vi.mocked(createSupabaseServerClient);
+const mockedGetRoleListings = vi.mocked(getRoleListings);
+
+describe("fetchRoleListings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to local listings when supabase is unavailable", async () => {
+    mockedCreateSupabaseServerClient.mockReturnValue(null);
+
+    const listings = await fetchRoleListings("en");
+
+    expect(mockedGetRoleListings).toHaveBeenCalledWith("en");
+    expect(listings).toHaveLength(1);
+  });
+
+  it("returns supabase data when available", async () => {
+    const order = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 2,
+          title: "Lead Recruiter",
+          team: "People",
+          location: "Berlin",
+          type: "Full-time",
+          summary: "Support global hiring."
+        }
+      ],
+      error: null
+    });
+    const select = vi.fn(() => ({ order }));
+    const from = vi.fn(() => ({ select }));
+    const schema = vi.fn(() => ({ from }));
+
+    mockedCreateSupabaseServerClient.mockReturnValue({ schema } as never);
+
+    const listings = await fetchRoleListings("en");
+
+    expect(schema).toHaveBeenCalledWith("public");
+    expect(from).toHaveBeenCalledWith("role_listings_view");
+    expect(select).toHaveBeenCalledWith("id,title,team,location,type,summary");
+    expect(order).toHaveBeenCalledWith("id");
+    expect(listings).toEqual([
+      {
+        id: 2,
+        title: "Lead Recruiter",
+        team: "People",
+        location: "Berlin",
+        type: "Full-time",
+        summary: "Support global hiring."
+      }
+    ]);
+  });
+
+  it("falls back when supabase returns an error", async () => {
+    const order = vi.fn().mockResolvedValue({
+      data: null,
+      error: new Error("Request failed")
+    });
+    const select = vi.fn(() => ({ order }));
+    const from = vi.fn(() => ({ select }));
+    const schema = vi.fn(() => ({ from }));
+
+    mockedCreateSupabaseServerClient.mockReturnValue({ schema } as never);
+
+    const listings = await fetchRoleListings("nl");
+
+    expect(mockedGetRoleListings).toHaveBeenCalledWith("nl");
+    expect(listings).toHaveLength(1);
+  });
+});

--- a/apps/jobs/src/lib/supabase/server.test.ts
+++ b/apps/jobs/src/lib/supabase/server.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createClient } from "@supabase/supabase-js";
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn()
+}));
+
+const mockedCreateClient = vi.mocked(createClient);
+
+describe("createSupabaseServerClient", () => {
+  afterEach(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_ANON_KEY;
+    vi.clearAllMocks();
+  });
+
+  it("returns null without environment configuration", () => {
+    expect(createSupabaseServerClient()).toBeNull();
+    expect(mockedCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("returns a configured client when env vars exist", () => {
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_ANON_KEY = "anon-key";
+    const client = { auth: {} };
+
+    mockedCreateClient.mockReturnValue(client as never);
+
+    expect(createSupabaseServerClient()).toBe(client);
+    expect(mockedCreateClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "anon-key",
+      {
+        auth: {
+          persistSession: false
+        }
+      }
+    );
+  });
+});

--- a/apps/jobs/src/lib/utils.test.ts
+++ b/apps/jobs/src/lib/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  it("merges classes and resolves conflicts", () => {
+    expect(cn("text-white", "text-black")).toBe("text-black");
+  });
+});

--- a/apps/jobs/src/test/setup.ts
+++ b/apps/jobs/src/test/setup.ts
@@ -1,0 +1,4 @@
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+vi.mock("server-only", () => ({}));

--- a/apps/jobs/tsconfig.json
+++ b/apps/jobs/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["next-env.d.ts", "src", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/jobs/vitest.config.ts
+++ b/apps/jobs/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -22,16 +22,18 @@
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^20.14.12",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@vitest/coverage-v8": "^2.0.5",
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.5",
     "postcss": "^8.4.41",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4",
-    "vitest": "^2.0.5",
-    "@vitest/coverage-v8": "^2.0.5"
+    "vitest": "^2.0.5"
   }
 }

--- a/apps/portal/src/components/ui/button.test.tsx
+++ b/apps/portal/src/components/ui/button.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Button } from "@/components/ui/button";
+
+describe("Button", () => {
+  it("renders with default styling", () => {
+    render(<Button>Apply now</Button>);
+
+    const button = screen.getByRole("button", { name: "Apply now" });
+
+    expect(button).toHaveClass("bg-white");
+  });
+});

--- a/apps/portal/src/lib/supabase/queries.test.ts
+++ b/apps/portal/src/lib/supabase/queries.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchHeroListings } from "@/lib/supabase/queries";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getHeroListings } from "@/data/hero";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServerClient: vi.fn()
+}));
+
+vi.mock("@/data/hero", () => ({
+  getHeroListings: vi.fn(() => [
+    {
+      id: 1,
+      title: "Hero Designer",
+      team: "Design",
+      location: "Remote",
+      type: "Full-time",
+      summary: "Build radiant experiences."
+    }
+  ])
+}));
+
+const mockedCreateSupabaseServerClient = vi.mocked(createSupabaseServerClient);
+const mockedGetHeroListings = vi.mocked(getHeroListings);
+
+describe("fetchHeroListings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to local listings when supabase is unavailable", async () => {
+    mockedCreateSupabaseServerClient.mockReturnValue(null);
+
+    const listings = await fetchHeroListings("en");
+
+    expect(mockedGetHeroListings).toHaveBeenCalledWith("en");
+    expect(listings).toHaveLength(1);
+  });
+
+  it("returns supabase data when available", async () => {
+    const order = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 2,
+          title: "Hero Engineer",
+          team: "Engineering",
+          location: "Amsterdam",
+          type: "Full-time",
+          summary: "Ship reliable platforms."
+        }
+      ],
+      error: null
+    });
+    const select = vi.fn(() => ({ order }));
+    const from = vi.fn(() => ({ select }));
+    const schema = vi.fn(() => ({ from }));
+
+    mockedCreateSupabaseServerClient.mockReturnValue({ schema } as never);
+
+    const listings = await fetchHeroListings("en");
+
+    expect(schema).toHaveBeenCalledWith("public");
+    expect(from).toHaveBeenCalledWith("hero_listings_view");
+    expect(select).toHaveBeenCalledWith("id,title,team,location,type,summary");
+    expect(order).toHaveBeenCalledWith("id");
+    expect(listings).toEqual([
+      {
+        id: 2,
+        title: "Hero Engineer",
+        team: "Engineering",
+        location: "Amsterdam",
+        type: "Full-time",
+        summary: "Ship reliable platforms."
+      }
+    ]);
+  });
+
+  it("falls back when supabase returns an error", async () => {
+    const order = vi.fn().mockResolvedValue({
+      data: null,
+      error: new Error("Request failed")
+    });
+    const select = vi.fn(() => ({ order }));
+    const from = vi.fn(() => ({ select }));
+    const schema = vi.fn(() => ({ from }));
+
+    mockedCreateSupabaseServerClient.mockReturnValue({ schema } as never);
+
+    const listings = await fetchHeroListings("nl");
+
+    expect(mockedGetHeroListings).toHaveBeenCalledWith("nl");
+    expect(listings).toHaveLength(1);
+  });
+});

--- a/apps/portal/src/lib/supabase/server.test.ts
+++ b/apps/portal/src/lib/supabase/server.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createClient } from "@supabase/supabase-js";
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn()
+}));
+
+const mockedCreateClient = vi.mocked(createClient);
+
+describe("createSupabaseServerClient", () => {
+  afterEach(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_ANON_KEY;
+    vi.clearAllMocks();
+  });
+
+  it("returns null without environment configuration", () => {
+    expect(createSupabaseServerClient()).toBeNull();
+    expect(mockedCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("returns a configured client when env vars exist", () => {
+    process.env.SUPABASE_URL = "https://example.supabase.co";
+    process.env.SUPABASE_ANON_KEY = "anon-key";
+    const client = { auth: {} };
+
+    mockedCreateClient.mockReturnValue(client as never);
+
+    expect(createSupabaseServerClient()).toBe(client);
+    expect(mockedCreateClient).toHaveBeenCalledWith(
+      "https://example.supabase.co",
+      "anon-key",
+      {
+        auth: {
+          persistSession: false
+        }
+      }
+    );
+  });
+});

--- a/apps/portal/src/lib/utils.test.ts
+++ b/apps/portal/src/lib/utils.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "@/lib/utils";
+
+describe("cn", () => {
+  it("merges classes and resolves conflicts", () => {
+    expect(cn("px-2", "py-1", "px-4")).toBe("py-1 px-4");
+  });
+});

--- a/apps/portal/src/test/setup.ts
+++ b/apps/portal/src/test/setup.ts
@@ -1,0 +1,4 @@
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+vi.mock("server-only", () => ({}));

--- a/apps/portal/tsconfig.json
+++ b/apps/portal/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["next-env.d.ts", "src", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/portal/vitest.config.ts
+++ b/apps/portal/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,3 @@
 # Tests
 
-Shared test utilities and integration tests live here.
+Shared test utilities and integration tests live here. End-to-end coverage lives under `tests/e2e` and uses Playwright.

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@hero/e2e",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.47.2"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+
+const webServer = process.env.PLAYWRIGHT_BASE_URL
+  ? undefined
+  : {
+      command: "pnpm --filter @hero/portal dev -- --hostname 0.0.0.0 --port 3000",
+      url: baseURL,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000
+    };
+
+export default defineConfig({
+  testDir: "./tests",
+  reporter: "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry"
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ],
+  webServer
+});

--- a/tests/e2e/tests/portal-home.spec.ts
+++ b/tests/e2e/tests/portal-home.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "@playwright/test";
+
+test("portal home page renders the hero headline", async ({ page }) => {
+  await page.goto("/en");
+
+  await expect(
+    page.getByRole("heading", { name: "Discover roles built for hero impact" })
+  ).toBeVisible();
+});


### PR DESCRIPTION
### Motivation
- Provide a baseline test setup for unit/UI and E2E to meet the repository coverage requirement and enable UI regression checks. 
- Ensure apps use a consistent test environment (`jsdom`) with React Testing Library and `jest-dom` matchers for DOM assertions. 
- Add a lightweight Playwright harness for simple end-to-end smoke tests under `tests/e2e`. 

### Description
- Configure Vitest to run in `jsdom` and load a shared setup file in `apps/portal/vitest.config.ts` and `apps/jobs/vitest.config.ts`, and add `src/test/setup.ts` files that import `@testing-library/jest-dom/vitest` and mock `server-only`. 
- Add baseline unit/UI tests for utilities, Supabase server/query fallbacks, and the `Button` component across `apps/portal` and `apps/jobs` to improve coverage (`*.test.ts{,x}` files). 
- Update `tsconfig.json` in both apps to include testing types (`vitest/globals`, `@testing-library/jest-dom`) and add testing deps to app `package.json` files. 
- Add Playwright E2E scaffold under `tests/e2e` including `package.json`, `playwright.config.ts`, and a simple `portal-home.spec.ts` that validates the home headline, and document the required CI command `turbo run build test lint` in `README.md`. 

### Testing
- No automated test suite was executed as `pnpm install` failed due to an environment/network proxy error when trying to download pnpm, so `vitest` and Playwright runs were not performed. 
- All new test files and config were committed and are runnable locally or in CI after dependencies are installed with `pnpm install` and tests executed with `pnpm test` or Playwright with `pnpm --filter @hero/e2e test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e5acd55c88320980713bf6ee11dfd)